### PR TITLE
Add Shortcuts, Repositories, allow using unsupported (yet) steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sequences of standard gremlin steps, other shortcuts and even add new initially 
 Remember ActiveRecord scopes? Shortcuts are very similar. `Grumlin::Shortcuts#with_shortcuts` wraps a given object into
 a proxy object that simply proxies all methods existing in the wrapped object to it and handles shortcuts.
 
-**Important**: if a shortcut's name matches a name of a method defined on the wrapper object, this shortcut will be
+**Important**: if a shortcut's name matches a name of a method defined on the wrapped object, this shortcut will be
 be ignored because methods have higher priority. You cannot override supported by Grumlin steps with shortcuts, 
 `Grumlin::Shortcuts.shortcut` will raise an `ArgumentError`. Please carefully choose names for your shortcuts.
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,11 @@ class MyRepository
   # It can add shortcuts from another repository or a shortcuts module
   shortcuts_from ChooseShortcut
   
-  shortcut :hasColor do |color|
-    has(:color, color)
+  shortcut :red_triangles do |color|
+    # hasAll unwraps a hash of properties into a chain of `has` steps:
+    # hasAll(name1: :value, name2: :value) == has(:name1, :value).has(:name2, :value)
+    # the `props` shortcut does exactly the same but with `property` steps.
+    hasAll(T.label => :triangle, color: color)
   end
 
   # g and __ are already aware of shortcuts 

--- a/lib/grumlin.rb
+++ b/lib/grumlin.rb
@@ -106,6 +106,10 @@ module Grumlin
     end
   end
 
+  def self.supported_steps
+    @supported_steps ||= (Grumlin::AnonymousStep::SUPPORTED_STEPS + Grumlin::Tools::U::SUPPORTED_STEPS).sort.uniq
+  end
+
   @pool_mutex = Mutex.new
 
   class << self

--- a/lib/grumlin.rb
+++ b/lib/grumlin.rb
@@ -107,7 +107,7 @@ module Grumlin
   end
 
   def self.supported_steps
-    @supported_steps ||= (Grumlin::AnonymousStep::SUPPORTED_STEPS + Grumlin::Tools::U::SUPPORTED_STEPS).sort.uniq
+    @supported_steps ||= (Grumlin::AnonymousStep::SUPPORTED_STEPS + Grumlin::Expressions::U::SUPPORTED_STEPS).sort.uniq
   end
 
   @pool_mutex = Mutex.new

--- a/lib/grumlin/anonymous_step.rb
+++ b/lib/grumlin/anonymous_step.rb
@@ -18,8 +18,12 @@ module Grumlin
 
     SUPPORTED_STEPS.each do |step|
       define_method(step) do |*args|
-        add_step(step, args)
+        step(step, args)
       end
+    end
+
+    def step(name, args)
+      self.class.new(name, *args, previous_step: self)
     end
 
     def inspect
@@ -30,12 +34,6 @@ module Grumlin
 
     def bytecode(no_return: false)
       @bytecode ||= Bytecode.new(self, no_return: no_return)
-    end
-
-    private
-
-    def add_step(step_name, args)
-      self.class.new(step_name, *args, previous_step: self)
     end
   end
 end

--- a/lib/grumlin/bytecode.rb
+++ b/lib/grumlin/bytecode.rb
@@ -42,7 +42,7 @@ module Grumlin
       return arg unless arg.is_a?(AnonymousStep)
 
       arg.args.flatten.each.with_object([arg.name.to_s]) do |a, res|
-        res << if a.instance_of?(AnonymousStep)
+        res << if a.respond_to?(:bytecode)
                  a.bytecode.send(serialization_method)
                else
                  serialize_arg(a, serialization_method: serialization_method)

--- a/lib/grumlin/bytecode.rb
+++ b/lib/grumlin/bytecode.rb
@@ -38,12 +38,12 @@ module Grumlin
     # depending on the `serialization_method` parameter. I should be either `:to_readable_bytecode` for human readable
     # representation or `:to_bytecode` for query.
     def serialize_arg(arg, serialization_method: :to_bytecode)
-      return arg.send(serialization_method) if arg.respond_to?(serialization_method)
+      return arg.public_send(serialization_method) if arg.respond_to?(serialization_method)
       return arg unless arg.is_a?(AnonymousStep)
 
       arg.args.flatten.each.with_object([arg.name.to_s]) do |a, res|
         res << if a.respond_to?(:bytecode)
-                 a.bytecode.send(serialization_method)
+                 a.bytecode.public_send(serialization_method)
                else
                  serialize_arg(a, serialization_method: serialization_method)
                end

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -4,7 +4,7 @@ module Grumlin
   module Repository
     module InstanceMethods
       def __
-        with_shortcuts(Grumlin::Tools::U)
+        with_shortcuts(Grumlin::Expressions::U)
       end
 
       def g
@@ -14,7 +14,7 @@ module Grumlin
 
     def self.extended(base)
       base.extend(Grumlin::Shortcuts)
-      base.include(Grumlin::Tools)
+      base.include(Grumlin::Expressions)
       base.include(InstanceMethods)
 
       base.shortcuts_from(Grumlin::Shortcuts::Properties)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -2,9 +2,20 @@
 
 module Grumlin
   module Repository
+    module InstanceMethods
+      def __
+        with_shortcuts(Grumlin::Tools::U)
+      end
+
+      def g
+        with_shortcuts(Grumlin::Traversal.new)
+      end
+    end
+
     def self.extended(base)
       base.extend(Grumlin::Shortcuts)
       base.include(Grumlin::Tools)
+      base.include(InstanceMethods)
 
       base.shortcuts_from(Grumlin::Shortcuts::Properties)
     end

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -5,17 +5,8 @@ module Grumlin
     def self.extended(base)
       base.extend(Grumlin::Shortcuts)
       base.include(Grumlin::Tools)
-      base.shortcut :props do |**props|
-        props.reduce(self) do |tt, (prop, value)|
-          tt.property(prop, value)
-        end
-      end
 
-      base.shortcut :hasAll do |**props|
-        props.reduce(self) do |tt, (prop, value)|
-          tt.has(prop, value)
-        end
-      end
+      base.shortcuts_from(Grumlin::Shortcuts::Properties)
     end
   end
 end

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -2,25 +2,9 @@
 
 module Grumlin
   module Repository
-    module InstanceMethods
-      def __
-        with_shortcuts(Grumlin::Tools::U)
-      end
-
-      def g
-        with_shortcuts(Grumlin::Traversal.new)
-      end
-
-      private
-
-      def with_shortcuts(obj)
-        ShortcutProxy.new(obj, self.class.shortcuts)
-      end
-    end
-
     def self.extended(base)
-      base.include Grumlin::Tools
-      base.include InstanceMethods
+      base.extend(Grumlin::Shortcuts)
+      base.include(Grumlin::Tools)
       base.shortcut :props do |**props|
         props.reduce(self) do |tt, (prop, value)|
           tt.property(prop, value)
@@ -32,14 +16,6 @@ module Grumlin
           tt.has(prop, value)
         end
       end
-    end
-
-    def shortcut(name, &block)
-      shortcuts[name.to_sym] = block
-    end
-
-    def shortcuts
-      @shortcuts ||= {}
     end
   end
 end

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -35,7 +35,7 @@ module Grumlin
     end
 
     def shortcut(name, &block)
-      shortcuts[name] = block
+      shortcuts[name.to_sym] = block
     end
 
     def shortcuts

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Grumlin
+  module Repository
+    module InstanceMethods
+      def __
+        with_shortcuts(Grumlin::Tools::U)
+      end
+
+      def g
+        with_shortcuts(Grumlin::Traversal.new)
+      end
+
+      private
+
+      def with_shortcuts(obj)
+        ShortcutProxy.new(obj, self.class.shortcuts)
+      end
+    end
+
+    def self.extended(base)
+      base.include Grumlin::Tools
+      base.include InstanceMethods
+      base.shortcut :props do |**props|
+        props.reduce(self) do |tt, (prop, value)|
+          tt.property(prop, value)
+        end
+      end
+
+      base.shortcut :hasAll do |**props|
+        props.reduce(self) do |tt, (prop, value)|
+          tt.has(prop, value)
+        end
+      end
+    end
+
+    def shortcut(name, &block)
+      shortcuts[name] = block
+    end
+
+    def shortcuts
+      @shortcuts ||= {}
+    end
+  end
+end

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -2,9 +2,9 @@
 
 module Grumlin
   class ShortcutProxy
-    # shortcuts: {"name": ->() {}}
     extend Forwardable
 
+    # shortcuts: {"name": ->() {}}
     def initialize(object, shortcuts)
       @object = object
       @shortcuts = shortcuts
@@ -18,14 +18,16 @@ module Grumlin
       super
     end
 
+    # For some reason the interpreter thinks it's private for some reason
+    public def respond_to_missing?(name, include_private = false) # rubocop:disable Style/AccessModifierDeclarations
+      name = name.to_sym
+      @object.respond_to?(name) || @shortcuts.key?(name) || super
+    end
+
     def_delegator :@object, :to_s
 
     def inspect
       @object.inspect
-    end
-
-    def respond_to_missing?(name)
-      @object.respond_to?(name) || @shortcuts.key?(name)
     end
 
     private

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -20,7 +20,7 @@ module Grumlin
       super
     end
 
-    # For some reason the interpreter thinks it's private for some reason
+    # For some reason the interpreter thinks it's private
     public def respond_to_missing?(name, include_private = false) # rubocop:disable Style/AccessModifierDeclarations
       name = name.to_sym
       @object.respond_to?(name) || @shortcuts.key?(name) || super

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -12,10 +12,10 @@ module Grumlin
       @shortcuts = shortcuts
     end
 
-    def method_missing(name, *args)
-      return wrap_result(@object.send(name, *args)) if @object.respond_to?(name)
+    def method_missing(name, *args, **params)
+      return wrap_result(@object.send(name, *args, **params)) if @object.respond_to?(name)
 
-      return wrap_result(@object.instance_exec(*args, &@shortcuts[name])) if @shortcuts.key?(name)
+      return wrap_result(instance_exec(*args, **params, &@shortcuts[name])) if @shortcuts.key?(name)
 
       super
     end

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Grumlin
+  class ShortcutProxy
+    # shortcuts: {"name": ->() {}}
+    extend Forwardable
+
+    def initialize(object, shortcuts)
+      @object = object
+      @shortcuts = shortcuts
+    end
+
+    def method_missing(name, *args)
+      return wrap_result(@object.send(name, *args)) if @object.respond_to?(name)
+
+      return wrap_result(@object.instance_exec(*args, &@shortcuts[name])) if @shortcuts.key?(name)
+
+      super
+    end
+
+    def_delegator :@object, :to_s
+
+    def inspect
+      @object.inspect
+    end
+
+    def respond_to_missing?(name)
+      @object.respond_to?(name) || @shortcuts.key?(name)
+    end
+
+    private
+
+    def wrap_result(result)
+      return self.class.new(result, @shortcuts) if result.is_a?(AnonymousStep)
+
+      result
+    end
+  end
+end

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -12,10 +12,10 @@ module Grumlin
       @shortcuts = shortcuts
     end
 
-    def method_missing(name, *args, **params)
-      return wrap_result(@object.send(name, *args, **params)) if @object.respond_to?(name)
+    def method_missing(name, *args)
+      return wrap_result(@object.send(name, *args)) if @object.respond_to?(name)
 
-      return wrap_result(instance_exec(*args, **params, &@shortcuts[name])) if @shortcuts.key?(name)
+      return wrap_result(instance_exec(*args, &@shortcuts[name])) if @shortcuts.key?(name)
 
       super
     end

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -4,6 +4,8 @@ module Grumlin
   class ShortcutProxy
     extend Forwardable
 
+    attr_reader :object, :shortcuts
+
     # shortcuts: {"name": ->() {}}
     def initialize(object, shortcuts)
       @object = object

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -6,7 +6,7 @@ module Grumlin
 
     attr_reader :object, :shortcuts
 
-    # shortcuts: {"name": ->() {}}
+    # shortcuts: {"name": ->(arg) {}}
     def initialize(object, shortcuts)
       @object = object
       @shortcuts = shortcuts

--- a/lib/grumlin/shortcut_proxy.rb
+++ b/lib/grumlin/shortcut_proxy.rb
@@ -13,7 +13,7 @@ module Grumlin
     end
 
     def method_missing(name, *args)
-      return wrap_result(@object.send(name, *args)) if @object.respond_to?(name)
+      return wrap_result(@object.public_send(name, *args)) if @object.respond_to?(name)
 
       return wrap_result(instance_exec(*args, &@shortcuts[name])) if @shortcuts.key?(name)
 

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Grumlin
+  module Shortcuts
+    module InstanceMethods
+      def __
+        self.class.with_shortcuts(Grumlin::Tools::U)
+      end
+
+      def g
+        self.class.with_shortcuts(Grumlin::Traversal.new)
+      end
+    end
+
+    def self.extended(base)
+      base.include(InstanceMethods)
+    end
+
+    def shortcut(name, &block)
+      name = name.to_sym
+      if Grumlin::AnonymousStep::SUPPORTED_STEPS.include?(name) || Grumlin::Tools::U::SUPPORTED_STEPS.include?(name)
+        raise ArgumentError, "cannot use names of standard gremlin steps"
+      end
+
+      raise ArgumentError, "shortcut '#{name}' already exists" if shortcuts.key?(name)
+
+      shortcuts[name] = block
+    end
+
+    def from(other_shortcuts)
+      other_shortcuts.shortcuts.each do |name, block|
+        shortcut(name, &block)
+      end
+    end
+
+    def shortcuts
+      @shortcuts ||= {}
+    end
+
+    def with_shortcuts(obj)
+      ShortcutProxy.new(obj, shortcuts)
+    end
+  end
+end

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -27,7 +27,7 @@ module Grumlin
       shortcuts[name] = block
     end
 
-    def from(other_shortcuts)
+    def shortcuts_from(other_shortcuts)
       other_shortcuts.shortcuts.each do |name, block|
         shortcut(name, &block)
       end

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -16,6 +16,11 @@ module Grumlin
       base.include(InstanceMethods)
     end
 
+    def inherited(subclass)
+      super
+      subclass.shortcuts_from(self)
+    end
+
     def shortcut(name, &block)
       name = name.to_sym
       if @object.respond_to?(name) || Grumlin::Tools::U::SUPPORTED_STEPS.include?(name)

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -4,7 +4,7 @@ module Grumlin
   module Shortcuts
     module InstanceMethods
       def with_shortcuts(obj)
-        ShortcutProxy.new(obj, self.class.shortcuts)
+        ShortcutProxy.new(obj, self.class.shortcuts, parent: self)
       end
     end
 

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -23,9 +23,8 @@ module Grumlin
 
     def shortcut(name, &block)
       name = name.to_sym
-      if @object.respond_to?(name) || Grumlin::Tools::U::SUPPORTED_STEPS.include?(name)
-        raise ArgumentError, "cannot use names of standard gremlin steps"
-      end
+      # TODO: blocklist of names to avoid conflicts with standard methods?
+      raise ArgumentError, "cannot use names of standard gremlin steps" if Grumlin.supported_steps.include?(name)
 
       raise ArgumentError, "shortcut '#{name}' already exists" if shortcuts.key?(name)
 

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -3,12 +3,8 @@
 module Grumlin
   module Shortcuts
     module InstanceMethods
-      def __
-        self.class.with_shortcuts(Grumlin::Tools::U)
-      end
-
-      def g
-        self.class.with_shortcuts(Grumlin::Traversal.new)
+      def with_shortcuts(obj)
+        ShortcutProxy.new(obj, self.class.shortcuts)
       end
     end
 
@@ -39,10 +35,6 @@ module Grumlin
 
     def shortcuts
       @shortcuts ||= {}
-    end
-
-    def with_shortcuts(obj)
-      ShortcutProxy.new(obj, shortcuts)
     end
   end
 end

--- a/lib/grumlin/shortcuts.rb
+++ b/lib/grumlin/shortcuts.rb
@@ -18,7 +18,7 @@ module Grumlin
 
     def shortcut(name, &block)
       name = name.to_sym
-      if Grumlin::AnonymousStep::SUPPORTED_STEPS.include?(name) || Grumlin::Tools::U::SUPPORTED_STEPS.include?(name)
+      if @object.respond_to?(name) || Grumlin::Tools::U::SUPPORTED_STEPS.include?(name)
         raise ArgumentError, "cannot use names of standard gremlin steps"
       end
 

--- a/lib/grumlin/shortcuts/properties.rb
+++ b/lib/grumlin/shortcuts/properties.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Grumlin
+  module Shortcuts
+    module Properties
+      extend Grumlin::Shortcuts
+
+      shortcut :props do |**props|
+        props.reduce(self) do |tt, (prop, value)|
+          tt.property(prop, value)
+        end
+      end
+
+      shortcut :hasAll do |**props|
+        props.reduce(self) do |tt, (prop, value)|
+          tt.has(prop, value)
+        end
+      end
+    end
+  end
+end

--- a/lib/grumlin/shortcuts/properties.rb
+++ b/lib/grumlin/shortcuts/properties.rb
@@ -5,13 +5,13 @@ module Grumlin
     module Properties
       extend Grumlin::Shortcuts
 
-      shortcut :props do |**props|
+      shortcut :props do |props = {}|
         props.reduce(self) do |tt, (prop, value)|
           tt.property(prop, value)
         end
       end
 
-      shortcut :hasAll do |**props|
+      shortcut :hasAll do |props = {}|
         props.reduce(self) do |tt, (prop, value)|
           tt.has(prop, value)
         end

--- a/lib/grumlin/step.rb
+++ b/lib/grumlin/step.rb
@@ -36,9 +36,7 @@ module Grumlin
       end
     end
 
-    private
-
-    def add_step(step_name, args)
+    def step(step_name, args)
       self.class.new(@pool, step_name, *args, previous_step: self)
     end
   end

--- a/lib/grumlin/sugar.rb
+++ b/lib/grumlin/sugar.rb
@@ -3,7 +3,7 @@
 module Grumlin
   module Sugar
     def self.included(base)
-      base.include Grumlin::Tools
+      base.include(Grumlin::Tools)
     end
 
     def __

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -1,14 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe Grumlin::Repository, gremlin_server: true do
-  let(:repository) do
+  let(:repository_klass) do
     Class.new do
       extend Grumlin::Repository
-    end.new
+    end
+  end
+  let(:repository) { repository_klass.new }
+
+  describe "class methods" do
+    %i[shortcut shortcuts shortcuts_from with_shortcuts].each do |method|
+      it "responds to ##{method}" do
+        expect(repository_klass).to respond_to(method)
+      end
+    end
   end
 
-  it "works" do
-    p repository.g.V.props(a: 1, b: 1)
-    p repository.g.V.hasAll(a: 1, b: 1)
+  describe "instance methods" do
+    %i[__ g].each do |method|
+      it "responds to ##{method}" do
+        expect(repository).to respond_to(method)
+      end
+    end
+  end
+
+  describe "included shortcuts" do
+    it "includes props and hasAll shortcuts" do
+      expect(repository_klass.shortcuts.keys).to eq(%i[props hasAll])
+    end
   end
 end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::Repository, gremlin_server: true do
+  let(:repository) do
+    Class.new do
+      extend Grumlin::Repository
+    end.new
+  end
+
+  it "works" do
+    p repository.g.V.props(a: 1, b: 1)
+    p repository.g.V.hasAll(a: 1, b: 1)
+  end
+end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
   let(:repository_klass) do
     Class.new do
       extend Grumlin::Repository
+
+      shortcut :shortcut do
+        property(:shortcut, true)
+      end
     end
   end
   let(:repository) { repository_klass.new }
@@ -25,8 +29,8 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
   end
 
   describe "included shortcuts" do
-    it "includes props and hasAll shortcuts" do
-      expect(repository_klass.shortcuts.keys).to eq(%i[props hasAll])
+    it "includes shortcuts" do
+      expect(repository_klass.shortcuts.keys).to eq(%i[props hasAll shortcut])
     end
   end
 end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
   let(:repository) { repository_klass.new }
 
   describe "class methods" do
-    %i[shortcut shortcuts shortcuts_from with_shortcuts].each do |method|
+    %i[shortcut shortcuts shortcuts_from].each do |method|
       it "responds to ##{method}" do
         expect(repository_klass).to respond_to(method)
       end
@@ -21,7 +21,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
   end
 
   describe "instance methods" do
-    %i[__ g].each do |method|
+    %i[__ g with_shortcuts].each do |method|
       it "responds to ##{method}" do
         expect(repository).to respond_to(method)
       end

--- a/spec/grumlin/shortcut_proxy_spec.rb
+++ b/spec/grumlin/shortcut_proxy_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Grumlin::ShortcutProxy do
   let(:object) { double(fold: true, property: true) } # rubocop:disable RSpec/VerifiedDoubles
   let(:shortcuts) do
     {
-      custom_step: ->(arg) { property(:a, arg) }
+      custom_step: proc { |arg| property(:a, arg) }
     }
   end
 
@@ -63,9 +63,9 @@ RSpec.describe Grumlin::ShortcutProxy do
         let(:method_name) { :custom_step }
         let(:args) { [1] }
 
-        it "executes the shortcut in the context of the wrapper_object" do
+        it "executes the shortcut in the context of the proxy" do
           subject
-          expect(object).to have_received(:property).with(:a, 1)
+          expect(object).to have_received(:property).with(:a, 1, {})
         end
 
         it "returns a ShortcutProxy" do
@@ -96,7 +96,7 @@ RSpec.describe Grumlin::ShortcutProxy do
 
         it "executes the shortcut in the context of the wrapper_object" do
           subject
-          expect(object).to have_received(:property).with(:a, 1)
+          expect(object).to have_received(:property).with(:a, 1, {})
         end
 
         it "returns a ShortcutProxy" do

--- a/spec/grumlin/shortcut_proxy_spec.rb
+++ b/spec/grumlin/shortcut_proxy_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::ShortcutProxy do
+  let(:proxy) { described_class.new(object, shortcuts) }
+
+  let(:object) { double(fold: true, property: true) } # rubocop:disable RSpec/VerifiedDoubles
+  let(:shortcuts) do
+    {
+      custom_step: ->(arg) { property(:a, arg) }
+    }
+  end
+
+  describe "#respond_to_missing?" do
+    subject { proxy.respond_to_missing?(method_name) }
+
+    context "when method exists in the wrapped object" do
+      let(:method_name) { "fold" }
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when method is a shortcut" do
+      let(:method_name) { "custom_step" }
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when method is neither a shortcut nor object's method" do
+      let(:method_name) { "unknown" }
+
+      it "returns false" do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+
+  describe "#method_missing" do
+    subject { proxy.method_missing(method_name, *args) }
+
+    let(:args) { [] }
+
+    context "when result is not a step" do
+      let(:object) { double(fold: 1, property: 2) } # rubocop:disable RSpec/VerifiedDoubles
+
+      context "when method exists in the wrapped object" do
+        let(:method_name) { :fold }
+
+        it "delegates to object" do
+          subject
+          expect(object).to have_received(:fold)
+        end
+
+        it "returns a ShortcutProxy" do
+          expect(subject).to eq(1)
+        end
+      end
+
+      context "when method is a shortcut" do
+        let(:method_name) { :custom_step }
+        let(:args) { [1] }
+
+        it "executes the shortcut in the context of the wrapper_object" do
+          subject
+          expect(object).to have_received(:property).with(:a, 1)
+        end
+
+        it "returns a ShortcutProxy" do
+          expect(subject).to eq(2)
+        end
+      end
+    end
+
+    context "when result is a step" do
+      let(:object) { double(fold: Grumlin::AnonymousStep.new("step"), property: Grumlin::AnonymousStep.new("step")) } # rubocop:disable RSpec/VerifiedDoubles
+
+      context "when method exists in the wrapped object" do
+        let(:method_name) { :fold }
+
+        it "delegates to object" do
+          subject
+          expect(object).to have_received(:fold)
+        end
+
+        it "returns a ShortcutProxy" do
+          expect(subject).to be_a(described_class)
+        end
+      end
+
+      context "when method is a shortcut" do
+        let(:method_name) { :custom_step }
+        let(:args) { [1] }
+
+        it "executes the shortcut in the context of the wrapper_object" do
+          subject
+          expect(object).to have_received(:property).with(:a, 1)
+        end
+
+        it "returns a ShortcutProxy" do
+          expect(subject).to be_a(described_class)
+        end
+      end
+
+      context "when method is neither a shortcut nor object's method" do
+        let(:method_name) { :unknown }
+
+        include_examples "raises an exception", NoMethodError
+      end
+    end
+  end
+
+  describe "#inspect" do
+    subject { proxy.inspect }
+
+    it "delegates to object" do
+      allow(object).to receive(:inspect).and_return("object")
+      expect(subject).to eq("object")
+    end
+  end
+
+  describe "#to_s" do
+    subject { proxy.to_s }
+
+    it "delegates to object" do
+      allow(object).to receive(:to_s).and_return("object")
+      expect(subject).to eq("object")
+    end
+  end
+end

--- a/spec/grumlin/shortcut_proxy_spec.rb
+++ b/spec/grumlin/shortcut_proxy_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Grumlin::ShortcutProxy do
       context "when method is neither a shortcut nor object's method" do
         let(:method_name) { :unknown }
 
-        include_examples "raises an exception", NoMethodError
+        include_examples "raises an exception", NameError
       end
     end
   end

--- a/spec/grumlin/shortcut_proxy_spec.rb
+++ b/spec/grumlin/shortcut_proxy_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Grumlin::ShortcutProxy do
 
         it "executes the shortcut in the context of the proxy" do
           subject
-          expect(object).to have_received(:property).with(:a, 1, {})
+          expect(object).to have_received(:property).with(:a, 1)
         end
 
         it "returns a ShortcutProxy" do
@@ -96,7 +96,7 @@ RSpec.describe Grumlin::ShortcutProxy do
 
         it "executes the shortcut in the context of the wrapper_object" do
           subject
-          expect(object).to have_received(:property).with(:a, 1, {})
+          expect(object).to have_received(:property).with(:a, 1)
         end
 
         it "returns a ShortcutProxy" do

--- a/spec/grumlin/shortcuts/properties_spec.rb
+++ b/spec/grumlin/shortcuts/properties_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::Shortcuts::Properties do
+  describe "shortcut props" do
+    it "converts a hash into a charin of property calls" do
+      object1 = double(property: nil) # rubocop:disable RSpec/VerifiedDoubles
+      object = double(property: object1) # rubocop:disable RSpec/VerifiedDoubles
+      object.instance_exec(a: 1, b: 2, &described_class.shortcuts[:props])
+      expect(object).to have_received(:property).with(:a, 1)
+      expect(object1).to have_received(:property).with(:b, 2)
+    end
+  end
+
+  describe "shortcut hasAll" do
+    it "converts a hash into a charin of has calls" do
+      object1 = double(has: nil) # rubocop:disable RSpec/VerifiedDoubles
+      object = double(has: object1) # rubocop:disable RSpec/VerifiedDoubles
+      object.instance_exec(a: 1, b: 2, &described_class.shortcuts[:hasAll])
+      expect(object).to have_received(:has).with(:a, 1)
+      expect(object1).to have_received(:has).with(:b, 2)
+    end
+  end
+end

--- a/spec/grumlin/shortcuts_spec.rb
+++ b/spec/grumlin/shortcuts_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::Shortcuts do
+  let(:klass) do
+    Class.new do
+      extend Grumlin::Shortcuts
+
+      shortcut(:test_step1) { nil }
+    end
+  end
+
+  describe ".shortcut" do
+    context "when shortcut name conflicts with gremlin steps" do
+      subject { klass.shortcut(:has) { nil } }
+
+      include_examples "raises an exception", ArgumentError, "cannot use names of standard gremlin steps"
+    end
+
+    context "when shortcut name conflicts with other shortcut" do
+      subject { klass.shortcut(:test_step1) { nil } }
+
+      include_examples "raises an exception", ArgumentError, "shortcut 'test_step1' already exists"
+    end
+
+    context "when shortcut has no conflicts" do
+      it "add a new shortcut" do
+        klass.shortcut(:custom_step) { nil }
+        expect(klass.shortcuts.count).to eq(2)
+        expect(klass.shortcuts[:custom_step]).to be_a(Proc)
+      end
+    end
+  end
+
+  describe ".from" do
+    let(:another_klass) do
+      Class.new do
+        extend Grumlin::Shortcuts
+
+        shortcut(:test_step2) { nil }
+        shortcut(:test_step3) { nil }
+      end
+    end
+
+    it "adds all shortcuts from another class" do
+      klass.from(another_klass)
+      expect(klass.shortcuts.keys).to eq(%i[test_step1 test_step2 test_step3])
+    end
+  end
+
+  describe ".with_shortcuts" do
+    before do
+      klass.shortcut(:test_step4) { nil }
+    end
+
+    it "wraps given object and defined shortcuts into a ShortcutProxy" do
+      proxy = klass.with_shortcuts("test")
+      expect(proxy).to be_a(Grumlin::ShortcutProxy)
+      expect(proxy.object).to eq("test")
+      expect(proxy.shortcuts.keys).to eq(%i[test_step1 test_step4])
+    end
+  end
+end

--- a/spec/grumlin/shortcuts_spec.rb
+++ b/spec/grumlin/shortcuts_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe Grumlin::Shortcuts do
     end
   end
 
+  describe "inheritance" do
+    let(:another_klass) do
+      Class.new(klass) do
+        shortcut :shortcut1 do
+          property(:some_property, true)
+        end
+      end
+    end
+
+    it "allows using shortcuts defined in the ancestor" do
+      expect(another_klass.shortcuts.keys).to eq(%i[test_step1 shortcut1])
+    end
+  end
+
   describe ".shortcut" do
     context "when shortcut name conflicts with gremlin steps" do
       subject { klass.shortcut(:has) { nil } }

--- a/spec/grumlin/shortcuts_spec.rb
+++ b/spec/grumlin/shortcuts_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Grumlin::Shortcuts do
     end
   end
 
-  describe ".from" do
+  describe ".shortcuts_from" do
     let(:another_klass) do
       Class.new do
         extend Grumlin::Shortcuts
@@ -42,7 +42,7 @@ RSpec.describe Grumlin::Shortcuts do
     end
 
     it "adds all shortcuts from another class" do
-      klass.from(another_klass)
+      klass.shortcuts_from(another_klass)
       expect(klass.shortcuts.keys).to eq(%i[test_step1 test_step2 test_step3])
     end
   end

--- a/spec/grumlin/shortcuts_spec.rb
+++ b/spec/grumlin/shortcuts_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe Grumlin::Shortcuts do
     end
   end
 
-  describe ".with_shortcuts" do
+  describe "#with_shortcuts" do
     before do
       klass.shortcut(:test_step4) { nil }
     end
 
     it "wraps given object and defined shortcuts into a ShortcutProxy" do
-      proxy = klass.with_shortcuts("test")
+      proxy = klass.new.with_shortcuts("test")
       expect(proxy).to be_a(Grumlin::ShortcutProxy)
       expect(proxy.object).to eq("test")
       expect(proxy.shortcuts.keys).to eq(%i[test_step1 test_step4])

--- a/spec/support/graphml_importer.rb
+++ b/spec/support/graphml_importer.rb
@@ -31,7 +31,7 @@ class GraphMLImporter
         node.xpath("xmlns:data[not(@key='labelV')]").each do |attribute|
           key = attribute.attributes["key"].value
           cast_method = TYPES[properties[:node][key][0][:type]]
-          t = t.property(key, attribute.text.send(cast_method))
+          t = t.property(key, attribute.text.public_send(cast_method))
         end
       end
       t.iterate
@@ -50,7 +50,7 @@ class GraphMLImporter
         edge.xpath("xmlns:data[not(@key='labelE')]").each do |attribute|
           key = attribute.attributes["key"].value
           cast_method = TYPES[properties[:edge][key][0][:type]]
-          t = t.property(key, attribute.text.send(cast_method))
+          t = t.property(key, attribute.text.public_send(cast_method))
         end
       end
       t.iterate

--- a/spec/support/rspec/shared_examples.rb
+++ b/spec/support/rspec/shared_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "raises an exception" do |exception, message|
-  it "raises #{Exception.name}" do
+  it "raises #{exception.name}" do
     expect { subject }.to raise_error(exception, message)
   end
 end


### PR DESCRIPTION
[Rendered readme](https://github.com/babbel/grumlin/blob/add-shortcuts/README.md)

Main changes:
- Introduce a concept of Shortcuts - a tool for gremlin code sharing and defining custom steps similarly to ActiveRecord's scopes
- Let users use any step that are not yet supported by `Grumlin` with `AnonymousStep#step`
- Introduce a concept of Repository - a high level API with support for Shortcuts out of the box.