### PR TITLE
Add operator expressions, fix Module bloating, add steps, refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.14.2] - 2021-12-13
+
+- Fix `Module` bloating
+- Add `Operator` expressions
+- Add `__.coalesce` and `__.constant`
+- Add steps: `sum`, `sack`
+- Add configuration steps: `withSack`
+- Rename `Grumlin::Expressions::Tool` to `Grumlin::Expressions::Expression`
+
+
 ## [0.14.2] - 2021-12-12
 
 - Better exceptions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grumlin (0.14.2)
+    grumlin (0.14.3)
       async-pool (~> 0.3)
       async-websocket (~> 0.19)
       oj (~> 3.12)
@@ -68,7 +68,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
-    oj (3.13.9)
+    oj (3.13.10)
     overcommit (0.57.0)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)

--- a/lib/grumlin/anonymous_step.rb
+++ b/lib/grumlin/anonymous_step.rb
@@ -7,7 +7,7 @@ module Grumlin
     # TODO: add other steps
     SUPPORTED_STEPS = %i[E V addE addV and as both bothE by choose coalesce count dedup drop elementMap emit fold from
                          group groupCount has hasId hasLabel hasNot id in inE inV is label limit not or order out outE
-                         path project property range repeat sack select sideEffect skip tail to unfold union until
+                         path project property range repeat sack select sideEffect skip sum tail to unfold union until
                          valueMap values where with].freeze
 
     def initialize(name, *args, configuration_steps: [], previous_step: nil, **params)

--- a/lib/grumlin/anonymous_step.rb
+++ b/lib/grumlin/anonymous_step.rb
@@ -7,8 +7,8 @@ module Grumlin
     # TODO: add other steps
     SUPPORTED_STEPS = %i[E V addE addV and as both bothE by choose coalesce count dedup drop elementMap emit fold from
                          group groupCount has hasId hasLabel hasNot id in inE inV is label limit not or order out outE
-                         path project property range repeat select sideEffect skip tail to unfold union until valueMap
-                         values where with].freeze
+                         path project property range repeat sack select sideEffect skip tail to unfold union until
+                         valueMap values where with].freeze
 
     def initialize(name, *args, configuration_steps: [], previous_step: nil, **params)
       @name = name

--- a/lib/grumlin/expressions/expression.rb
+++ b/lib/grumlin/expressions/expression.rb
@@ -2,7 +2,7 @@
 
 module Grumlin
   module Expressions
-    module Tool
+    module Expression
       def define_steps(steps, tool_name)
         steps.each do |step|
           self.class.define_method step do

--- a/lib/grumlin/expressions/expression.rb
+++ b/lib/grumlin/expressions/expression.rb
@@ -5,7 +5,7 @@ module Grumlin
     module Expression
       def define_steps(steps, tool_name)
         steps.each do |step|
-          self.class.define_method step do
+          define_method step do
             name = "@#{step}"
             return instance_variable_get(name) if instance_variable_defined?(name)
 

--- a/lib/grumlin/expressions/operator.rb
+++ b/lib/grumlin/expressions/operator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Grumlin
+  module Expressions
+    module Operator
+      extend Expression
+
+      SUPPORTED_STEPS = %i[addAll and assign div max min minus mult or sum].freeze
+
+      define_steps(SUPPORTED_STEPS, "Operator")
+    end
+  end
+end

--- a/lib/grumlin/expressions/operator.rb
+++ b/lib/grumlin/expressions/operator.rb
@@ -3,11 +3,13 @@
 module Grumlin
   module Expressions
     module Operator
-      extend Expression
-
       SUPPORTED_STEPS = %i[addAll and assign div max min minus mult or sum].freeze
 
-      define_steps(SUPPORTED_STEPS, "Operator")
+      class << self
+        extend Expression
+
+        define_steps(SUPPORTED_STEPS, "Operator")
+      end
     end
   end
 end

--- a/lib/grumlin/expressions/order.rb
+++ b/lib/grumlin/expressions/order.rb
@@ -3,11 +3,13 @@
 module Grumlin
   module Expressions
     module Order
-      extend Expression
-
       SUPPORTED_STEPS = %i[asc desc].freeze
 
-      define_steps(SUPPORTED_STEPS, "Order")
+      class << self
+        extend Expression
+
+        define_steps(SUPPORTED_STEPS, "Order")
+      end
     end
   end
 end

--- a/lib/grumlin/expressions/order.rb
+++ b/lib/grumlin/expressions/order.rb
@@ -3,7 +3,7 @@
 module Grumlin
   module Expressions
     module Order
-      extend Tool
+      extend Expression
 
       SUPPORTED_STEPS = %i[asc desc].freeze
 

--- a/lib/grumlin/expressions/pop.rb
+++ b/lib/grumlin/expressions/pop.rb
@@ -3,7 +3,7 @@
 module Grumlin
   module Expressions
     module Pop
-      extend Tool
+      extend Expression
 
       SUPPORTED_STEPS = %i[all first last mixed].freeze
 

--- a/lib/grumlin/expressions/pop.rb
+++ b/lib/grumlin/expressions/pop.rb
@@ -3,11 +3,13 @@
 module Grumlin
   module Expressions
     module Pop
-      extend Expression
-
       SUPPORTED_STEPS = %i[all first last mixed].freeze
 
-      define_steps(SUPPORTED_STEPS, "Pop")
+      class << self
+        extend Expression
+
+        define_steps(SUPPORTED_STEPS, "Pop")
+      end
     end
   end
 end

--- a/lib/grumlin/expressions/scope.rb
+++ b/lib/grumlin/expressions/scope.rb
@@ -3,11 +3,13 @@
 module Grumlin
   module Expressions
     module Scope
-      extend Expression
-
       SUPPORTED_STEPS = %i[local].freeze
 
-      define_steps(SUPPORTED_STEPS, "Scope")
+      class << self
+        extend Expression
+
+        define_steps(SUPPORTED_STEPS, "Scope")
+      end
     end
   end
 end

--- a/lib/grumlin/expressions/scope.rb
+++ b/lib/grumlin/expressions/scope.rb
@@ -3,7 +3,7 @@
 module Grumlin
   module Expressions
     module Scope
-      extend Tool
+      extend Expression
 
       SUPPORTED_STEPS = %i[local].freeze
 

--- a/lib/grumlin/expressions/t.rb
+++ b/lib/grumlin/expressions/t.rb
@@ -3,11 +3,13 @@
 module Grumlin
   module Expressions
     module T
-      extend Expression
-
       SUPPORTED_STEPS = %i[id label].freeze
 
-      define_steps(SUPPORTED_STEPS, "T")
+      class << self
+        extend Expression
+
+        define_steps(SUPPORTED_STEPS, "T")
+      end
     end
   end
 end

--- a/lib/grumlin/expressions/t.rb
+++ b/lib/grumlin/expressions/t.rb
@@ -3,7 +3,7 @@
 module Grumlin
   module Expressions
     module T
-      extend Tool
+      extend Expression
 
       SUPPORTED_STEPS = %i[id label].freeze
 

--- a/lib/grumlin/expressions/u.rb
+++ b/lib/grumlin/expressions/u.rb
@@ -5,7 +5,7 @@ module Grumlin
     module U
       # TODO: add other start steps
       SUPPORTED_STEPS = %i[V addV coalesce constant count drop fold has hasLabel hasNot id in inE inV is label out outE
-                           outV project repeat select sum timeLimit unfold valueMap values].freeze
+                           outV project repeat select timeLimit unfold valueMap values].freeze
 
       class << self
         SUPPORTED_STEPS.each do |step|

--- a/lib/grumlin/expressions/u.rb
+++ b/lib/grumlin/expressions/u.rb
@@ -5,7 +5,7 @@ module Grumlin
     module U
       # TODO: add other start steps
       SUPPORTED_STEPS = %i[V addV count drop fold has hasLabel hasNot id in inE inV is label out outE outV project
-                           repeat select timeLimit unfold valueMap values].freeze
+                           repeat select sum timeLimit unfold valueMap values].freeze
 
       class << self
         SUPPORTED_STEPS.each do |step|

--- a/lib/grumlin/expressions/u.rb
+++ b/lib/grumlin/expressions/u.rb
@@ -4,8 +4,8 @@ module Grumlin
   module Expressions
     module U
       # TODO: add other start steps
-      SUPPORTED_STEPS = %i[V addV count drop fold has hasLabel hasNot id in inE inV is label out outE outV project
-                           repeat select sum timeLimit unfold valueMap values].freeze
+      SUPPORTED_STEPS = %i[V addV coalesce constant count drop fold has hasLabel hasNot id in inE inV is label out outE
+                           outV project repeat select sum timeLimit unfold valueMap values].freeze
 
       class << self
         SUPPORTED_STEPS.each do |step|

--- a/lib/grumlin/traversal.rb
+++ b/lib/grumlin/traversal.rb
@@ -5,7 +5,7 @@ module Grumlin
     # TODO: add other start steps
     SUPPORTED_STEPS = %i[E V addE addV].freeze
 
-    CONFIGURATION_STEPS = %i[withSideEffect].freeze
+    CONFIGURATION_STEPS = %i[withSack withSideEffect].freeze
 
     attr_reader :configuration_steps
 

--- a/lib/grumlin/version.rb
+++ b/lib/grumlin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grumlin
-  VERSION = "0.14.2"
+  VERSION = "0.14.3"
 end

--- a/spec/grumlin/expressions/operator_spec.rb
+++ b/spec/grumlin/expressions/operator_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::Expressions::Operator do
+  include_examples "has sorted constant", "SUPPORTED_STEPS"
+end


### PR DESCRIPTION
Changes:
- Fix `Module` bloating
- Add `Operator` expressions
- Add `__.coalesce` and `__.constant`
- Add steps: `sum`, `sack`
- Add configuration steps: `withSack`
- Rename `Grumlin::Expressions::Tool` to `Grumlin::Expressions::Expression` (leftover from https://github.com/babbel/grumlin/pull/41)