### PR TITLE
Add Repository#query

### DIFF
--- a/lib/grumlin.rb
+++ b/lib/grumlin.rb
@@ -100,6 +100,10 @@ module Grumlin
     end
   end
 
+  class RepositoryError < Error; end
+
+  class WrongQueryResult < RepositoryError; end
+
   class Config
     attr_accessor :url, :pool_size, :client_concurrency, :client_factory
 

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -27,11 +27,13 @@ module Grumlin
       base.shortcuts_from(Grumlin::Shortcuts::Properties)
     end
 
-    def query(name, return_mode: :list, &block) # rubocop:disable Metrics/AbcSize
+    def query(name, return_mode: :list, &query_block) # rubocop:disable Metrics/AbcSize
       validate_return_mode!(return_mode)
 
-      define_method name do |*args, query_params: {}, **params|
-        t = instance_exec(*args, **params, &block)
+      define_method name do |*args, query_params: {}, **params, &block|
+        t = instance_exec(*args, **params, &query_block)
+        return block.call(t) unless block.nil?
+
         raise WrongQueryResult, "queries must return traversals, given: #{t.class}" unless t.is_a?(Grumlin::Action)
 
         return t.profile.next if query_params[:profile] == true

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -32,7 +32,7 @@ module Grumlin
 
       define_method name do |*args, query_params: {}, **params, &block|
         t = instance_exec(*args, **params, &query_block)
-        return if t.nil?
+        return t if self.class.empty_result?(t)
 
         unless t.is_a?(Grumlin::Action)
           raise WrongQueryResult, "queries must return #{Grumlin::Action} given: #{t.class}"
@@ -54,6 +54,10 @@ module Grumlin
       return return_mode if RETURN_MODES.key?(return_mode)
 
       raise ArgumentError, "unsupported return mode #{return_mode}. Supported modes: #{RETURN_MODES.keys}"
+    end
+
+    def empty_result?(result)
+      result.nil? || (result.respond_to?(:empty?) && result.empty?)
     end
   end
 end

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -35,7 +35,8 @@ module Grumlin
         return t if self.class.empty_result?(t)
 
         unless t.is_a?(Grumlin::Action)
-          raise WrongQueryResult, "queries must return #{Grumlin::Action} given: #{t.class}"
+          raise WrongQueryResult,
+                "queries must return #{Grumlin::Action}, nil or an empty collection. Given: #{t.class}"
         end
 
         return block.call(t) unless block.nil?

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -45,7 +45,7 @@ module Grumlin
 
         return t if return_mode == :traversal
 
-        return t.send(RETURN_MODES[return_mode])
+        return t.public_send(RETURN_MODES[return_mode])
       end
     end
 

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -2,6 +2,13 @@
 
 module Grumlin
   module Repository
+    RETURN_MODES = {
+      list: :toList,
+      none: :iterate,
+      single: :next,
+      traversal: :nil
+    }.freeze
+
     module InstanceMethods
       def __
         TraversalStart.new(self.class.shortcuts)
@@ -18,6 +25,32 @@ module Grumlin
       base.include(InstanceMethods)
 
       base.shortcuts_from(Grumlin::Shortcuts::Properties)
+    end
+
+    def query(name, return_mode: :list, &block) # rubocop:disable Metrics/AbcSize
+      validate_return_mode!(return_mode)
+
+      define_method name do |*args, query_params: {}, **params|
+        t = instance_exec(*args, **params, &block)
+        raise WrongQueryResult, "queries must return traversals, given: #{t.class}" unless t.is_a?(Grumlin::Action)
+
+        return t.profile.next if query_params[:profile] == true
+        return t.profile(query_params[:profile]).next if query_params[:profile]
+
+        return_mode = query_params[:return_mode] || return_mode
+
+        self.class.validate_return_mode!(return_mode)
+
+        return t if return_mode == :traversal
+
+        return t.send(RETURN_MODES[return_mode])
+      end
+    end
+
+    def validate_return_mode!(return_mode)
+      return if RETURN_MODES.key?(return_mode)
+
+      raise ArgumentError, "unsupported return mode #{return_mode}. Supported modes: #{RETURN_MODES.keys}"
     end
   end
 end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -302,5 +302,21 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         expect(result.keys).to match_array(%i[dur metrics]) # Profiling data
       end
     end
+
+    context "when a block is given" do
+      let(:repository_class) do
+        Class.new do
+          extend Grumlin::Repository
+
+          query(:test_query) do |color|
+            g.V.hasAll(color: color)
+          end
+        end
+      end
+
+      it "yields the traversal" do
+        expect { |b| repository.test_query(:white, &b) }.to yield_with_args(Grumlin::Action)
+      end
+    end
   end
 end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -318,5 +318,21 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         expect { |b| repository.test_query(:white, &b) }.to yield_with_args(Grumlin::Action)
       end
     end
+
+    context "when a query block returns an unexpected value" do
+      let(:repository_class) do
+        Class.new do
+          extend Grumlin::Repository
+
+          query(:test_query) do
+            "test"
+          end
+        end
+      end
+
+      it "yields the traversal" do
+        expect { repository.test_query }.to raise_error(Grumlin::WrongQueryResult, "queries must return Grumlin::Action, nil or an empty collection. Given: String")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR introduces a new helper for `Grumlin::Repository` called `query`.

## Problem

Previously in order to query data using a repository one needed to define a method and put the query in it:
```ruby
class MyRepository
  extend Grumlin::Repository

  def my_query(some_param)
    g.V.hasLabel(:test).has(:property, some_param).toList
  end
end

MyRepository.new.my_query(:some_value)
```

It works fine till the moment one needs to profile or debug the query. There was no way to access the traversal itself outside of the repository and without editing the code.

**Pros:**
- Simple and transparent

**Cons:**
- No simple way to profile and debug queries

## Solution: `Grumlin::Repository#query`

This PR adds a new API to `Grumlin::Repository`. 

Instead of defining methods one can use `Grumlin::Repository#query`:

```ruby
class MyRepository
  extend Grumlin::Repository
  
  query(:my_query, return_mode: :list) do |some_param| # :list is the default return mode, also possible: :none, :single, :traversal
    g.V.hasLabel(:test).has(:property, some_param) # Note that one does not need to call `toList` or `next`
  end
end
```

**Pros:**
- Simplified profiling and debugging
- Fully backward compatible

**Cons:**
- Slightly more complicated implementation
- it's needed to use `next` instead of `return` for early returns

### Usage
```ruby

# By default usage is exactly the same
MyRepository.new.my_query(:some_value)
```
Each `return_mode` is mapped to particular termination step:
- `:list` - `toList`
- `:single` - `next`
- `:none` - `iterate`
- `:traversal` - do not execute the query and return traversal as is

`return_mode` may be overwritten by a caller:
```ruby
MyRepository.new.my_query(:some_value, query_params: { return_mode: :single })
```

### Profiling
In order to profile the query one simply needs to pass `query_params: { profile: true }` to the query.

```ruby
MyRepository.new.my_query(:some_value, query_params: { profile: true })
```
Instead of the results, profiling data will be returned.

### Debugging
Queries defined with `query` support yielding:

```ruby
MyRepository.new.my_query(:some_value) do |t|
  t.count.next # t is a traversal
end
```

### Ho it works
`Grumlin::Repository#query` defines a method called after the name of the query. The method wraps the block passed to `query` and handles the result of the block execution: either calling a termination step, `profile` step or returning/yielding the traversal as is. Block passed to `query` must return either a `Grumlin::Action` (result of any gremlin traversal or an empty result (empty collection or nil). if query returns an empty result, control is not yielded, and profiling parameters are ignored. If a query block returns something else, a `Grumlin::WrongQueryResult` will raise.

## TODO:
- [ ] Update README