### PR TITLE
Add support for postprocessing in query

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grumlin (0.16.1)
+    grumlin (0.17.0)
       async-pool (~> 0.3)
       async-websocket (~> 0.19)
       oj (~> 3.12)
@@ -44,7 +44,7 @@ GEM
     benchmark (0.1.1)
     childprocess (4.0.0)
     concurrent-ruby (1.1.8)
-    console (1.14.0)
+    console (1.15.0)
       fiber-local
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -27,7 +27,7 @@ module Grumlin
       base.shortcuts_from(Grumlin::Shortcuts::Properties)
     end
 
-    def query(name, return_mode: :list, &query_block) # rubocop:disable Metrics/AbcSize
+    def query(name, return_mode: :list, postprocess_with: nil, &query_block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       return_mode = validate_return_mode!(return_mode)
 
       define_method name do |*args, query_params: {}, **params, &block|
@@ -47,7 +47,9 @@ module Grumlin
 
         return t if return_mode == :traversal
 
-        t.public_send(RETURN_MODES[return_mode])
+        t.public_send(RETURN_MODES[return_mode]).tap do |result|
+          return send(postprocess_with, result) unless postprocess_with.nil?
+        end
       end
     end
 

--- a/lib/grumlin/typing.rb
+++ b/lib/grumlin/typing.rb
@@ -69,7 +69,7 @@ module Grumlin
       def cast_map(value)
         Hash[*value].transform_keys do |key|
           next key.to_sym if key.respond_to?(:to_sym)
-          next cast(key) if key[:@type]
+          next cast(key) if key[:@type] # TODO: g.V.group.by(:none_existing_property).next
 
           raise UnknownMapKey, key, value
         end.transform_values { |v| cast(v) }

--- a/lib/grumlin/version.rb
+++ b/lib/grumlin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grumlin
-  VERSION = "0.16.1"
+  VERSION = "0.17.0"
 end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -171,21 +171,51 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
   end
 
   describe "#query" do
-    subject { repository_class.query(:test_query, return_mode: return_mode) { g.V } }
+    context "when return_mode is passed" do
+      subject { repository_class.query(:test_query, return_mode: return_mode) { g.V } }
 
-    context "when return mode is valid" do
-      let(:return_mode) { :single }
+      context "when return mode is valid" do
+        let(:return_mode) { :single }
 
-      it "defines a method named after the query" do
-        subject
-        expect(repository).to respond_to(:test_query)
+        it "defines a method named after the query" do
+          subject
+          expect(repository).to respond_to(:test_query)
+        end
+      end
+
+      context "when return is not valid" do
+        let(:return_mode) { :unknown }
+
+        include_examples "raises an exception", ArgumentError, "unsupported return mode unknown. Supported modes: [:list, :none, :single, :traversal]"
       end
     end
 
-    context "when return is not valid" do
-      let(:return_mode) { :unknown }
+    context "when postprocess_with is passed" do
+      subject { repository_class.query(:test_query, postprocess_with: postprocess_with) { g.V } }
 
-      include_examples "raises an exception", ArgumentError, "unsupported return mode unknown. Supported modes: [:list, :none, :single, :traversal]"
+      context "when postprocess_with is a symbol" do
+        let(:postprocess_with) { :present }
+
+        it "defines a method named after the query" do
+          subject
+          expect(repository).to respond_to(:test_query)
+        end
+      end
+
+      context "when postprocess_with is callable" do
+        let(:postprocess_with) { ->(r) {} }
+
+        it "defines a method named after the query" do
+          subject
+          expect(repository).to respond_to(:test_query)
+        end
+      end
+
+      context "when postprocess_with is something else" do
+        let(:postprocess_with) { 100_500 }
+
+        include_examples "raises an exception", ArgumentError, "postprocess_with must be a String, Symbol or a callable object, given: Integer"
+      end
     end
   end
 
@@ -336,41 +366,59 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
     end
 
     context "when postprocess_with is passed" do
-      context "when method exists" do
+      context "when postprocess_with is a symbol or string" do
+        context "when method exists" do
+          let(:repository_class) do
+            Class.new do
+              extend Grumlin::Repository
+
+              query(:test_query, postprocess_with: :present) do
+                g.V
+              end
+
+              private
+
+              def present(_collection)
+                "test"
+              end
+            end
+          end
+
+          it "returns postprocessed data" do
+            expect(repository.test_query).to eq("test")
+          end
+        end
+
+        context "when method does not exist" do
+          let(:repository_class) do
+            Class.new do
+              extend Grumlin::Repository
+
+              query(:test_query, postprocess_with: :present) do
+                g.V
+              end
+            end
+          end
+
+          it "raises an error" do
+            expect { repository.test_query }.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      context "when postprocess_with is a lambda" do
         let(:repository_class) do
           Class.new do
             extend Grumlin::Repository
 
-            query(:test_query, postprocess_with: :present) do
+            query(:test_query, postprocess_with: ->(_r) { "test" }) do
               g.V
-            end
-
-            private
-
-            def present(_collection)
-              "test"
             end
           end
         end
 
         it "returns postprocessed data" do
           expect(repository.test_query).to eq("test")
-        end
-      end
-
-      context "when method does not exist" do
-        let(:repository_class) do
-          Class.new do
-            extend Grumlin::Repository
-
-            query(:test_query, postprocess_with: :present) do
-              g.V
-            end
-          end
-        end
-
-        it "raises an error" do
-          expect { repository.test_query }.to raise_error(NoMethodError)
         end
       end
     end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -330,8 +330,48 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         end
       end
 
-      it "yields the traversal" do
+      it "raises an exception" do
         expect { repository.test_query }.to raise_error(Grumlin::WrongQueryResult, "queries must return Grumlin::Action, nil or an empty collection. Given: String")
+      end
+    end
+
+    context "when postprocess_with is passed" do
+      context "when method exists" do
+        let(:repository_class) do
+          Class.new do
+            extend Grumlin::Repository
+
+            query(:test_query, postprocess_with: :present) do
+              g.V
+            end
+
+            private
+
+            def present(_collection)
+              "test"
+            end
+          end
+        end
+
+        it "returns postprocessed data" do
+          expect(repository.test_query).to eq("test")
+        end
+      end
+
+      context "when method does not exist" do
+        let(:repository_class) do
+          Class.new do
+            extend Grumlin::Repository
+
+            query(:test_query, postprocess_with: :present) do
+              g.V
+            end
+          end
+        end
+
+        it "raises an error" do
+          expect { repository.test_query }.to raise_error(NoMethodError)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR extends the feature added in https://github.com/babbel/grumlin/pull/67.

`Grumlin::Repository#query` now supports a new parameter called `postprocess_with`. It may be a callable object or a symbol(or a string).

In case of a callable object(a proc, lambda or a any object responding to `call`), the object will be called after the query is executed, the result will be passed a parameter.

In case of a symbol - eponymous method defined on the repository will be called.

This feature may be useful when query results need to be somehow postprocessed, presented or wrapped into objects, see examples:

```ruby
class MyRepository
  extend Grumlin::Repository

  query :some_query, postrocess_with: :present do
    g.V
  end

  private
 
  def present(colection) # collection is a result of query execution
    collection.map { |node| { node_id: node[:id]  } }
  end
end
```
same postprocessing using a lambda:

```ruby
class MyRepository
  extend Grumlin::Repository

  query :some_query, postrocess_with: ->(collection){ collection.map { |node| { node_id: node[:id]  } } } do
    g.V
  end
end
```
