### PR TITLE
Add generic CRUD operations to Repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Naming/MethodParameterName:
     - outV
     - inVLabel
     - outVLabel
+    - to
 
 RSpec/NamedSubject:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grumlin (0.17.0)
+    grumlin (0.18.0)
       async-pool (~> 0.3)
       async-websocket (~> 0.19)
       oj (~> 3.12)

--- a/README.md
+++ b/README.md
@@ -73,13 +73,11 @@ class MyRepository
 end
 ```
 
-<!--- TODO: readme needs to be updated, with_shortcuts does not exist anymore. --->
 #### Shortcuts
 
 **Shortcuts** is a way to share and organize gremlin code. They let developers define their own steps consisting of
 sequences of standard gremlin steps, other shortcuts and even add new initially unsupported by Grumlin steps.
-Remember ActiveRecord scopes? Shortcuts are very similar. `Grumlin::Shortcuts#with_shortcuts` wraps a given object into
-a proxy object that simply proxies all methods existing in the wrapped object to it and handles shortcuts.
+Remember ActiveRecord scopes? Shortcuts are very similar.
 
 **Important**: if a shortcut's name matches a name of a method defined on the wrapped object, this shortcut will be
 be ignored because methods have higher priority. You cannot override supported by Grumlin steps with shortcuts, 
@@ -129,17 +127,18 @@ class MyRepository
 
   # Wrapping a traversal
   def red_triangles
-    with_shortcuts(g).V.hasLabel(:triangle)
-                       .hasColor("red")
-                       .toList
+    g(self.class.shortcuts).V.hasLabel(:triangle)
+       .hasColor("red")
+       .toList
   end
 
   # Wrapping _
   def something_else
-    with_shortcuts(g).V.hasColor("red")
-                       .repeat(with_shortcuts(__)
-                       .out(:has)
-                       .hasColor("blue")).toList
+    g(self.class.shortcuts).V.hasColor("red")
+       .repeat(__(self.class.shortcuts))
+       .out(:has)
+       .hasColor("blue")
+       .toList
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ Each `return_mode` is mapped to a particular termination step:
 - `:none` - `iterate`
 - `:traversal` - do not execute the query and return the traversal as is
 
+`Grumlin::Repository` also provides a set of generic CRUD operations:
+- `add_vertex(label, id = nil, **properties)`
+- `add_edge(label, id = nil, from:, to:, **properties)`
+- `drop_vertex(id)`
+- `drop_edge(id = nil, from: nil, to: nil, label: nil)`
+- `upsert_vertex(label, id, create_properties: {}, update_properties: {})`
+- `upsert_edge(label, from:, to:, create_properties: {}, update_properties: {})`
+
 **Usage**
 
 To execute the query defined in a query block one simply needs to call a method with the same name:

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -39,6 +39,14 @@ module Grumlin
         t = t.props(T.id => id) unless id.nil?
         t.props(**properties).next
       end
+
+      def add_edge(label, id = nil, from:, to:, **properties)
+        id ||= properties[T.id]
+        properties = properties.except(T.label)
+        properties[T.id] = id
+
+        g.addE(label).from(__.V(from)).to(__.V(to)).props(**properties).next
+      end
     end
 
     def self.extended(base)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -47,6 +47,18 @@ module Grumlin
 
         g.addE(label).from(__.V(from)).to(__.V(to)).props(**properties).next
       end
+
+      def upsert_vertex(id, label, create_properties: {}, update_properties: {}) # rubocop:disable Metrics/AbcSize
+        create_properties = create_properties.except(T.id, T.label)
+        update_properties = update_properties.except(T.id, T.label)
+        g.V(id)
+         .fold
+         .coalesce(
+           __.unfold,
+           __.addV(label).props(**create_properties.merge(T.id => id))
+         ).props(**update_properties)
+         .next
+      end
     end
 
     def self.extended(base)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -18,6 +18,10 @@ module Grumlin
         TraversalStart.new(self.class.shortcuts)
       end
 
+      def drop_vertex(id)
+        g.V(id).drop.iterate
+      end
+
       def drop_edge(id = nil, from: nil, to: nil, label: nil) # rubocop:disable Metrics/AbcSize
         raise ArgumentError, "either id or from:, to: and label: must be passed" if [id, from, to, label].all?(&:nil?)
         return g.E(id).drop.iterate unless id.nil?
@@ -25,10 +29,6 @@ module Grumlin
         raise ArgumentError, "from:, to: and label: must be passed" if [from, to, label].any?(&:nil?)
 
         g.V(from).outE(label).where(__.inV.hasId(to)).limit(1).drop.iterate
-      end
-
-      def drop_vertex(id)
-        g.V(id).drop.iterate
       end
     end
 

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -80,6 +80,7 @@ module Grumlin
       private
 
       # A polyfill for Hash#except for ruby 2.x environments without ActiveSupport
+      # TODO: delete and use native Hash#except when after ruby 2.7 is deprecated.
       def except(hash, *keys)
         return hash.except(*keys) if hash.respond_to?(:except)
 

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -32,6 +32,9 @@ module Grumlin
       end
 
       def add_vertex(label, id = nil, **properties)
+        id ||= properties[T.id]
+        properties = properties.except(T.id)
+
         t = g.addV(label)
         t = t.props(T.id => id) unless id.nil?
         t.props(**properties).next

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -17,6 +17,15 @@ module Grumlin
       def g
         TraversalStart.new(self.class.shortcuts)
       end
+
+      def drop_edge(id = nil, from: nil, to: nil, label: nil) # rubocop:disable Metrics/AbcSize
+        raise ArgumentError, "either id or from:, to: and label: must be passed" if [id, from, to, label].all?(&:nil?)
+        return g.E(id).drop.iterate unless id.nil?
+
+        raise ArgumentError, "from:, to: and label: must be passed" if [from, to, label].any?(&:nil?)
+
+        g.V(from).outE(label).where(__.inV.hasId(to)).limit(1).drop.iterate
+      end
     end
 
     def self.extended(base)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -30,6 +30,12 @@ module Grumlin
 
         g.V(from).outE(label).where(__.inV.hasId(to)).limit(1).drop.iterate
       end
+
+      def add_vertex(label, id = nil, **properties)
+        t = g.addV(label)
+        t = t.props(T.id => id) unless id.nil?
+        t.props(**properties).next
+      end
     end
 
     def self.extended(base)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -59,6 +59,21 @@ module Grumlin
          ).props(**update_properties)
          .next
       end
+
+      # Only from and to are used to find the existing edge, if one wants to assign an id to a created edge,
+      # it must be passed as T.id in via create_properties.
+      def upsert_edge(label, from:, to:, create_properties: {}, update_properties: {}) # rubocop:disable Metrics/AbcSize
+        create_properties = create_properties.except(T.label)
+        update_properties = update_properties.except(T.id, T.label)
+
+        g.V(from)
+         .outE(label).where(__.inV.hasId(to))
+         .fold
+         .coalesce(
+           __.unfold,
+           __.addE(label).from(__.V(from)).to(__.V(to)).props(**create_properties)
+         ).props(**update_properties).next
+      end
     end
 
     def self.extended(base)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -48,7 +48,7 @@ module Grumlin
         g.addE(label).from(__.V(from)).to(__.V(to)).props(**properties).next
       end
 
-      def upsert_vertex(id, label, create_properties: {}, update_properties: {}) # rubocop:disable Metrics/AbcSize
+      def upsert_vertex(label, id, create_properties: {}, update_properties: {}) # rubocop:disable Metrics/AbcSize
         create_properties = create_properties.except(T.id, T.label)
         update_properties = update_properties.except(T.id, T.label)
         g.V(id)

--- a/lib/grumlin/repository.rb
+++ b/lib/grumlin/repository.rb
@@ -26,6 +26,10 @@ module Grumlin
 
         g.V(from).outE(label).where(__.inV.hasId(to)).limit(1).drop.iterate
       end
+
+      def drop_vertex(id)
+        g.V(id).drop.iterate
+      end
     end
 
     def self.extended(base)

--- a/lib/grumlin/version.rb
+++ b/lib/grumlin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grumlin
-  VERSION = "0.17.0"
+  VERSION = "0.18.0"
 end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
     end
 
     describe "#upsert_vertex" do
-      subject { repository.upsert_vertex(id, :test, create_properties: create_properties, update_properties: update_properties) }
+      subject { repository.upsert_vertex(:test, id, create_properties: create_properties, update_properties: update_properties) }
 
       let(:id) { 123 }
       let(:create_properties) { { key: :value } }

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -134,6 +134,68 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         end
       end
     end
+
+    describe "#add_vertex" do
+      subject { repository.add_vertex(:test, id, **properties) }
+
+      let(:id) { nil }
+      let(:properties) { { key: :value } }
+
+      context "when id is passed as an argument" do
+        let(:id) { 123 }
+
+        it "creates a vertex with given id" do
+          subject
+          expect(g.V(id).next.id).to eq(id)
+          expect(g.V(id).elementMap.next).to eq({ id: 123, key: "value", label: "test" })
+        end
+      end
+
+      context "when id is passed as an :id property" do
+        let(:properties) { super().merge(id: 124) }
+
+        it "creates a vertex with random and an id property" do
+          subject
+          expect(g.V.has(:key, :value)).not_to eq(124)
+          expect(g.V.has(:key, :value).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+        end
+      end
+
+      context "when id is passed as T.id property" do
+        let(:properties) { super().merge({ T.id => 124 }) }
+
+        xit "creates a vertex with given id" do # TODO: fix passing props to the :props and :hasAll shortcuts
+          subject
+          expect(g.V(124).next.id).to eq(124)
+          expect(g.V(124).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+        end
+      end
+
+      context "when id is nil" do
+        xit ""
+      end
+
+      context "when id is passed as an argument and as :id" do
+        let(:id) { 123 }
+        let(:properties) { super().merge(id: 124) }
+
+        xit ""
+      end
+
+      context "when id is passed as an argument and as T.id" do
+        let(:id) { 123 }
+        let(:properties) { super().merge({ T.id => 124 }) }
+
+        xit ""
+      end
+
+      context "when id is passed as an argument, as :id and as T.id" do
+        let(:id) { 123 }
+        let(:properties) { super().merge({ id: 124, T.id => 125 }) }
+
+        xit ""
+      end
+    end
   end
 
   describe "included shortcuts" do

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -204,6 +204,56 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         end
       end
     end
+
+    describe "#add_edge" do
+      subject { repository.add_edge(:test_label, id, from: from, to: to, **properties) }
+
+      let(:from) { 1 }
+      let(:to) { 2 }
+      let(:properties) { { key: :value } }
+
+      before do
+        g.addV(:test).property(T.id, from)
+         .addV(:test).property(T.id, to).iterate
+      end
+
+      context "when id is passed as an argument" do
+        let(:id) { 123 }
+
+        it "creates an edge" do
+          expect { subject }.to change { g.E.count.next }.by(1)
+          expect(g.E(id).elementMap.next).to eq({ T.id => 123, T.label => "test_label",
+                                                  "IN" => { T.id => 2, T.label => "test" },
+                                                  "OUT" => { T.id => 1, T.label => "test" },
+                                                  key: "value" })
+        end
+
+        context "when id is also passed as a property" do
+          let(:properties) { super().merge({ T.id => 124 }) }
+
+          it "creates an edge" do
+            expect { subject }.to change { g.E.count.next }.by(1)
+            expect(g.E(id).elementMap.next).to eq({ T.id => 123, T.label => "test_label",
+                                                    "IN" => { T.id => 2, T.label => "test" },
+                                                    "OUT" => { T.id => 1, T.label => "test" },
+                                                    key: "value" })
+          end
+        end
+      end
+
+      context "when id is passed as a property" do
+        let(:id) { nil }
+        let(:properties) { super().merge({ T.id => 124 }) }
+
+        it "creates an edge" do
+          expect { subject }.to change { g.E.count.next }.by(1)
+          expect(g.E(id).elementMap.next).to eq({ T.id => 124, T.label => "test_label",
+                                                  "IN" => { T.id => 2, T.label => "test" },
+                                                  "OUT" => { T.id => 1, T.label => "test" },
+                                                  key: "value" })
+        end
+      end
+    end
   end
 
   describe "included shortcuts" do

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -110,6 +110,30 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         end
       end
     end
+
+    describe "#drop_vertex" do
+      subject { repository.drop_vertex(id) }
+
+      before do
+        g.addV(:test).property(T.id, 123).iterate
+      end
+
+      context "when vertex exists" do
+        let(:id) { 123 }
+
+        it "deletes the vertex" do
+          expect { subject }.to change { g.V.count.next }.by(-1)
+        end
+      end
+
+      context "when vertex does not exist" do
+        let(:id) { 124 }
+
+        it "deletes the vertex" do
+          expect { subject }.not_to(change { g.V.count.next })
+        end
+      end
+    end
   end
 
   describe "included shortcuts" do

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         it "creates a vertex with given id" do
           subject
           expect(g.V(id).next.id).to eq(id)
-          expect(g.V(id).elementMap.next).to eq({ id: 123, key: "value", label: "test" })
+          expect(g.V(id).elementMap.next).to eq({ T.id => 123, key: "value", T.label => "test" })
         end
       end
 
@@ -157,7 +157,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         it "creates a vertex with random and an id property" do
           subject
           expect(g.V.has(:key, :value)).not_to eq(124)
-          expect(g.V.has(:key, :value).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+          expect(g.V.has(:key, :value).elementMap.next.except(T.id)).to eq({ id: 124, key: "value", T.label => "test" }) # T.id is random
         end
       end
 
@@ -167,7 +167,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         it "creates a vertex with given id" do
           subject
           expect(g.V(124).next.id).to eq(124)
-          expect(g.V(124).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+          expect(g.V(124).elementMap.next).to eq({ T.id => 124, key: "value", T.label => "test" })
         end
       end
 
@@ -178,7 +178,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         it "creates a vertex with given id" do
           subject
           expect(g.V(id).next.id).to eq(id)
-          expect(g.V(id).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+          expect(g.V(id).elementMap.next).to eq({ T.id => 123, id: 124, key: "value", T.label => "test" })
         end
       end
 
@@ -189,7 +189,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         it "creates a vertex with given id" do
           subject
           expect(g.V(id).next.id).to eq(id)
-          expect(g.V(id).elementMap.next).to eq({ id: 123, key: "value", label: "test" })
+          expect(g.V(id).elementMap.next).to eq({ T.id => 123, key: "value", T.label => "test" })
         end
       end
 
@@ -200,7 +200,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
         it "creates a vertex with given id" do
           subject
           expect(g.V(id).next.id).to eq(id)
-          expect(g.V(id).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+          expect(g.V(id).elementMap.next).to eq({ T.id => 123, id: 124, key: "value", T.label => "test" })
         end
       end
     end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -33,6 +33,30 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
       end
     end
 
+    describe "#drop_vertex" do
+      subject { repository.drop_vertex(id) }
+
+      before do
+        g.addV(:test).property(T.id, 123).iterate
+      end
+
+      context "when vertex exists" do
+        let(:id) { 123 }
+
+        it "deletes the vertex" do
+          expect { subject }.to change { g.V.count.next }.by(-1)
+        end
+      end
+
+      context "when vertex does not exist" do
+        let(:id) { 124 }
+
+        it "deletes the vertex" do
+          expect { subject }.not_to(change { g.V.count.next })
+        end
+      end
+    end
+
     describe "#drop_edge" do
       context "when no arguments passed" do
         subject { repository.drop_edge }
@@ -107,30 +131,6 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
           subject { repository.drop_edge(from: 123, to: 234) }
 
           include_examples "raises an exception", ArgumentError, "from:, to: and label: must be passed"
-        end
-      end
-    end
-
-    describe "#drop_vertex" do
-      subject { repository.drop_vertex(id) }
-
-      before do
-        g.addV(:test).property(T.id, 123).iterate
-      end
-
-      context "when vertex exists" do
-        let(:id) { 123 }
-
-        it "deletes the vertex" do
-          expect { subject }.to change { g.V.count.next }.by(-1)
-        end
-      end
-
-      context "when vertex does not exist" do
-        let(:id) { 124 }
-
-        it "deletes the vertex" do
-          expect { subject }.not_to(change { g.V.count.next })
         end
       end
     end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -164,36 +164,44 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
       context "when id is passed as T.id property" do
         let(:properties) { super().merge({ T.id => 124 }) }
 
-        xit "creates a vertex with given id" do # TODO: fix passing props to the :props and :hasAll shortcuts
+        it "creates a vertex with given id" do
           subject
           expect(g.V(124).next.id).to eq(124)
           expect(g.V(124).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
         end
       end
 
-      context "when id is nil" do
-        xit ""
-      end
-
       context "when id is passed as an argument and as :id" do
         let(:id) { 123 }
         let(:properties) { super().merge(id: 124) }
 
-        xit ""
+        it "creates a vertex with given id" do
+          subject
+          expect(g.V(id).next.id).to eq(id)
+          expect(g.V(id).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+        end
       end
 
       context "when id is passed as an argument and as T.id" do
         let(:id) { 123 }
         let(:properties) { super().merge({ T.id => 124 }) }
 
-        xit ""
+        it "creates a vertex with given id" do
+          subject
+          expect(g.V(id).next.id).to eq(id)
+          expect(g.V(id).elementMap.next).to eq({ id: 123, key: "value", label: "test" })
+        end
       end
 
       context "when id is passed as an argument, as :id and as T.id" do
         let(:id) { 123 }
         let(:properties) { super().merge({ id: 124, T.id => 125 }) }
 
-        xit ""
+        it "creates a vertex with given id" do
+          subject
+          expect(g.V(id).next.id).to eq(id)
+          expect(g.V(id).elementMap.next).to eq({ id: 124, key: "value", label: "test" })
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds a few generic CRUD operations to the Repository module:
- add_vertex
- add_edge
- drop_vertex
- drop_edge
- upsert_vertex
- upsert_edge

**Usage:**
```ruby
class MyRepository
  extend Grumlin::Repository

  def foo
    pp add_vertex(:test, 1, property: :value)
    pp g.V.count.next
    drop_vertex(1)
    pp g.V.count.next

    pp upsert_vertex(:test, 1, create_properties: { proprety: :value })
    pp upsert_vertex(:test, 1, update_properties: { another_property: :value })
    pp g.V.count.next

    add_vertex(:test, 2)
    pp g.V.count.next

    add_edge(:test, from: 1, to: 2, update_properties: { property: :value })
    pp g.E.count.next

    upsert_edge(:test, from: 1, to: 2, update_properties: { another_property: :value })
    pp g.E.count.next

    drop_edge(from: 1, to: 2, label: :test)
    pp g.E.count.next
  end
end
```