### PR TITLE
Wrap some server errors into specific exceptions

### DIFF
--- a/lib/async/channel.rb
+++ b/lib/async/channel.rb
@@ -42,7 +42,6 @@ module Async
       @closed = true
     end
 
-    # TODO: cover me
     def close!
       return if closed?
 

--- a/lib/async/channel.rb
+++ b/lib/async/channel.rb
@@ -18,6 +18,10 @@ module Async
       @closed
     end
 
+    def open?
+      !@closed
+    end
+
     # Methods for a publisher
     def <<(payload)
       raise(ChannelClosedError, "Cannot send to a closed channel") if @closed
@@ -36,6 +40,14 @@ module Async
 
       @queue << [:close]
       @closed = true
+    end
+
+    # TODO: cover me
+    def close!
+      return if closed?
+
+      exception(ChannelClosedError.new("Channel was forcefully closed"))
+      close
     end
 
     # Methods for a subscriber

--- a/lib/grumlin.rb
+++ b/lib/grumlin.rb
@@ -80,6 +80,21 @@ module Grumlin
 
   class ServerError < ServerSideError; end
 
+  class AlreadyExistsError < ServerError
+    attr_reader :id
+
+    # TODO: parse message and assign @id
+    # NOTE: Neptune does not return id.
+  end
+
+  class VertexAlreadyExistsError < AlreadyExistsError; end
+  class EdgeAlreadyExistsError < AlreadyExistsError; end
+
+  class ConcurrentInsertFailedError < ServerError; end
+
+  class ConcurrentVertexInsertFailedError < ConcurrentInsertFailedError; end
+  class ConcurrentEdgeInsertFailedError < ConcurrentInsertFailedError; end
+
   class ServerSerializationError < ServerSideError; end
 
   class ServerTimeoutError < ServerSideError; end

--- a/lib/grumlin.rb
+++ b/lib/grumlin.rb
@@ -83,6 +83,12 @@ module Grumlin
   class AlreadyExistsError < ServerError
     attr_reader :id
 
+    def initialize(status, query)
+      super
+      id = status[:message].split(":").last.strip
+      @id = id == "" ? nil : id
+    end
+
     # TODO: parse message and assign @id
     # NOTE: Neptune does not return id.
   end

--- a/spec/grumlin/request_dispatcher_spec.rb
+++ b/spec/grumlin/request_dispatcher_spec.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::RequestDispatcher, async: true do
+  let(:dispatcher) { described_class.new }
+
+  describe "#add_request" do
+    subject { dispatcher.add_request({ requestId: 123 }) }
+
+    context "when request is new" do
+      it "adds a request" do
+        expect { subject }.to change { dispatcher.requests.count }.by(1)
+        expect(dispatcher.requests[123][:request]).to eq({ requestId: 123 })
+        expect(dispatcher.requests[123][:result]).to eq([])
+        expect(dispatcher.requests[123][:channel]).to be_an_instance_of(Async::Channel)
+      end
+    end
+
+    context "when request has already been added" do
+      before do
+        dispatcher.add_request({ requestId: 123 })
+      end
+
+      include_examples "raises an exception", described_class::RequestAlreadyAddedError
+
+      it "does not add the request" do
+        expect do
+          subject
+        rescue StandardError
+          nil
+        end.not_to(change { dispatcher.requests.count })
+      end
+    end
+  end
+
+  describe "#add_response" do
+    subject { dispatcher.add_response(response) }
+
+    context "when request is known" do
+      before do
+        dispatcher.add_request({ requestId: 123 })
+      end
+
+      context "when result is successful" do
+        context "when status is 200" do
+          let(:response) { { requestId: 123, status: { code: 200 }, result: { data: "some data" } } }
+
+          context "when there were no partial content responses previously" do
+            it "sends results via the response channel" do
+              channel = dispatcher.requests[123][:channel]
+              task = reactor.async do
+                expect(channel.dequeue).to eq(["some data"])
+              end
+              subject
+              task.wait
+            end
+
+            it "removes the request" do
+              expect { subject }.to change { dispatcher.requests[123] }.from(Hash).to(nil)
+            end
+
+            it "closes the response channel" do
+              channel = dispatcher.requests[123][:channel]
+              expect { subject }.to change(channel, :closed?).from(false).to(true)
+            end
+          end
+
+          context "when there were a partial content response previously" do
+            before do
+              dispatcher.add_response({ requestId: 123, status: { code: 206 }, result: { data: "some partial data" } })
+            end
+
+            it "sends full results via the response channel" do
+              channel = dispatcher.requests[123][:channel]
+              task = reactor.async do
+                expect(channel.dequeue).to eq(["some partial data", "some data"])
+              end
+              subject
+              task.wait
+            end
+
+            it "removes the request" do
+              expect { subject }.to change { dispatcher.requests[123] }.from(Hash).to(nil)
+            end
+
+            it "closes the response channel" do
+              channel = dispatcher.requests[123][:channel]
+              expect { subject }.to change(channel, :closed?).from(false).to(true)
+            end
+          end
+        end
+
+        context "when status is 204" do
+          let(:response) { { requestId: 123, status: { code: 204 } } }
+
+          it "sends results via the response channel" do
+            channel = dispatcher.requests[123][:channel]
+            task = reactor.async do
+              expect(channel.dequeue).to eq([])
+            end
+            subject
+            task.wait
+          end
+
+          it "removes the request" do
+            expect { subject }.to change { dispatcher.requests[123] }.from(Hash).to(nil)
+          end
+
+          it "closes the response channel" do
+            channel = dispatcher.requests[123][:channel]
+            expect { subject }.to change(channel, :closed?).from(false).to(true)
+          end
+        end
+
+        context "when status is 206" do
+          let(:response) { { requestId: 123, status: { code: 206 }, result: { data: "some partial data" } } }
+
+          it "does not send anything via the response channel" do
+            channel = dispatcher.requests[123][:channel]
+            task = reactor.async do
+              expect(channel.dequeue).to be_nil
+            end
+            subject
+            # dispatcher does not close the channel because it waits for new results
+            # in order to unblock the coroutine we need to close it manually.
+            channel.close
+            task.wait
+          end
+
+          it "adds the partial results to the request results" do
+            expect { subject }.to(change { dispatcher.requests[123][:result] }.from([]).to(["some partial data"]))
+          end
+
+          it "does not remove the request" do
+            expect { subject }.not_to(change { dispatcher.requests.count })
+          end
+
+          it "does not close the response channel" do
+            channel = dispatcher.requests[123][:channel]
+            expect { subject }.not_to change(channel, :closed?)
+          end
+        end
+      end
+
+      context "when result is an error" do
+        shared_examples "sends an exception via the response channel" do |exception|
+          it "sends #{exception} via the response channel" do
+            channel = dispatcher.requests[123][:channel]
+            task = reactor.async do
+              expect { channel.dequeue }.to raise_error(exception)
+            end
+            subject
+            task.wait
+          end
+
+          it "closes the response channel" do
+            channel = dispatcher.requests[123][:channel]
+            expect { subject }.to change(channel, :closed?).from(false).to(true)
+          end
+
+          it "removes the request" do
+            expect { subject }.to change { dispatcher.requests[123] }.from(Hash).to(nil)
+          end
+        end
+
+        context "when status is 500" do
+          let(:response) { { requestId: 123, status: { code: 500, message: message } } }
+
+          context "when vertex already exists" do
+            let(:message) { "Vertex with id already exists: 1234" }
+
+            include_examples "sends an exception via the response channel", Grumlin::VertexAlreadyExistsError
+          end
+
+          context "when edge already exists" do
+            let(:message) { "Edge with id already exists: 1234" }
+
+            include_examples "sends an exception via the response channel", Grumlin::EdgeAlreadyExistsError
+          end
+
+          context "when concurrent vertex insert failed" do
+            let(:message) { "Failed to complete Insert operation for a Vertex due to conflicting concurrent" }
+
+            include_examples "sends an exception via the response channel", Grumlin::ConcurrentVertexInsertFailedError
+          end
+
+          context "when concurrent edge insert failed" do
+            let(:message) { "Failed to complete Insert operation for an Edge due to conflicting concurrent" }
+
+            include_examples "sends an exception via the response channel", Grumlin::ConcurrentEdgeInsertFailedError
+          end
+        end
+
+        context "when status is 499" do
+          context "when status is 499" do
+            let(:response) { { requestId: 123, status: { code: 499, message: "" } } }
+
+            include_examples "sends an exception via the response channel", Grumlin::InvalidRequestArgumentsError
+          end
+        end
+
+        context "when status is 597" do
+          let(:response) { { requestId: 123, status: { code: 597, message: "" } } }
+
+          include_examples "sends an exception via the response channel", Grumlin::ScriptEvaluationError
+        end
+
+        context "when status is 599" do
+          let(:response) { { requestId: 123, status: { code: 599, message: "" } } }
+
+          include_examples "sends an exception via the response channel", Grumlin::ServerSerializationError
+        end
+
+        context "when status is 598" do
+          let(:response) { { requestId: 123, status: { code: 598, message: "" } } }
+
+          include_examples "sends an exception via the response channel", Grumlin::ServerTimeoutError
+        end
+
+        context "when status is 401" do
+          let(:response) { { requestId: 123, status: { code: 401, message: "" } } }
+
+          include_examples "sends an exception via the response channel", Grumlin::ClientSideError
+        end
+
+        context "when status is 407" do
+          let(:response) { { requestId: 123, status: { code: 407, message: "" } } }
+
+          include_examples "sends an exception via the response channel",  Grumlin::ClientSideError
+        end
+
+        context "when status is 498" do
+          let(:response) { { requestId: 123, status: { code: 498, message: "" } } }
+
+          include_examples "sends an exception via the response channel", Grumlin::ClientSideError
+        end
+      end
+    end
+
+    context "when request is unknown" do
+      let(:response) { { requestId: 123 } }
+
+      include_examples "raises an exception", described_class::UnknownRequestError
+    end
+  end
+
+  describe "#ongoing_request?" do
+    subject { dispatcher.ongoing_request?(123) }
+
+    context "when request is ongoing" do
+      before do
+        dispatcher.add_request({ requestId: 123 })
+      end
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when request is unknown" do
+      it "returns false" do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+
+  describe "#clear" do
+    subject { dispatcher.clear }
+
+    before do
+      dispatcher.add_request({ requestId: 123 })
+      dispatcher.add_request({ requestId: 124 })
+    end
+
+    it "sends errors to all channels" do
+      tasks = [123, 124].map do |id|
+        channel = dispatcher.requests[id][:channel]
+        reactor.async do
+          expect { channel.dequeue }.to raise_error(Async::Channel::ChannelClosedError, "Channel was forcefully closed")
+        end
+      end
+      subject
+      tasks.each(&:wait)
+    end
+
+    it "closes all channels" do
+      channels = [123, 124].map do |id|
+        dispatcher.requests[id][:channel]
+      end
+      expect(channels).to all(be_open)
+      subject
+      expect(channels).to all(be_closed)
+    end
+
+    it "clears requests" do
+      expect { subject }.to change { dispatcher.requests.empty? }.from(false).to(true)
+    end
+  end
+end

--- a/spec/grumlin/request_dispatcher_spec.rb
+++ b/spec/grumlin/request_dispatcher_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Grumlin::RequestDispatcher, async: true do
           context "when there were no partial content responses previously" do
             it "sends results via the response channel" do
               channel = dispatcher.requests[123][:channel]
-              task = reactor.async do
+              task = Async do
                 expect(channel.dequeue).to eq(["some data"])
               end
               subject
@@ -71,7 +71,7 @@ RSpec.describe Grumlin::RequestDispatcher, async: true do
 
             it "sends full results via the response channel" do
               channel = dispatcher.requests[123][:channel]
-              task = reactor.async do
+              task = Async do
                 expect(channel.dequeue).to eq(["some partial data", "some data"])
               end
               subject
@@ -94,7 +94,7 @@ RSpec.describe Grumlin::RequestDispatcher, async: true do
 
           it "sends results via the response channel" do
             channel = dispatcher.requests[123][:channel]
-            task = reactor.async do
+            task = Async do
               expect(channel.dequeue).to eq([])
             end
             subject
@@ -116,7 +116,7 @@ RSpec.describe Grumlin::RequestDispatcher, async: true do
 
           it "does not send anything via the response channel" do
             channel = dispatcher.requests[123][:channel]
-            task = reactor.async do
+            task = Async do
               expect(channel.dequeue).to be_nil
             end
             subject
@@ -145,7 +145,7 @@ RSpec.describe Grumlin::RequestDispatcher, async: true do
         shared_examples "sends an exception via the response channel" do |exception|
           it "sends #{exception} via the response channel" do
             channel = dispatcher.requests[123][:channel]
-            task = reactor.async do
+            task = Async do
               expect { channel.dequeue }.to raise_error(exception)
             end
             subject
@@ -274,7 +274,7 @@ RSpec.describe Grumlin::RequestDispatcher, async: true do
     it "sends errors to all channels" do
       tasks = [123, 124].map do |id|
         channel = dispatcher.requests[id][:channel]
-        reactor.async do
+        Async do
           expect { channel.dequeue }.to raise_error(Async::Channel::ChannelClosedError, "Channel was forcefully closed")
         end
       end

--- a/spec/grumlin/stress_spec.rb
+++ b/spec/grumlin/stress_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "stress test", gremlin_server: true, timeout: 120 do
 
   context "when task is stopped by timeout" do
     it "succeeds" do
-      t = reactor.async do |task|
+      t = Async do |task|
         task.with_timeout(3) do
           loop do
             upsert_query

--- a/spec/grumlin_spec.rb
+++ b/spec/grumlin_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe Grumlin do
     end
   end
 
+  describe Grumlin::AlreadyExistsError do
+    subject { described_class.new(status, []) }
+
+    context "when message contains an id" do
+      let(:status) { { message: "Vertex with id already exists: test_id" } }
+
+      it "parses and assigns parsed id" do
+        expect(subject.id).to eq("test_id")
+      end
+    end
+
+    # AWS neptune does not return an id for some reason
+    context "when message does not contain an id" do
+      let(:status) { { message: "Vertex with id already exists: " } }
+
+      it "does not fail and does not assign id" do
+        expect(subject.id).to be_nil
+      end
+    end
+  end
+
   describe "#definitions" do
     # if these tests fail try running `rake definitions:format`
     describe "[:steps]" do


### PR DESCRIPTION
Changes:
- Wrap `ServerSideError` with messages like  "Vertex with id already exists:" and "Edge with id already exists:" into `VertexAlreadyExistsError` and `EdgeAlreadyExistsError` accordingly
- Wrap `ServerSideError` with messages like "Failed to complete Insert operation for a Vertex due to conflicting concurrent" and "Failed to complete Insert operation for an Edge due to conflicting concurrent" into `ConcurrentVertexInsertFailedError` and `ConcurrentEdgeInsertFailedError` accordingly
- Cover `RequestDispatcher` with tests, fix found issues

**No breaking changes**