### PR TITLE
Add basic support for traversal strategies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grumlin (0.20.1)
+    grumlin (0.20.2)
       async-pool (~> 0.3)
       async-websocket (~> 0.19)
       oj (~> 3.13)

--- a/lib/definitions.yml
+++ b/lib/definitions.yml
@@ -82,6 +82,7 @@ steps:
   configuration:
   - withSack
   - withSideEffect
+  - withStrategies
 expressions:
   cardinality:
   - list

--- a/lib/grumlin/steppable.rb
+++ b/lib/grumlin/steppable.rb
@@ -13,8 +13,7 @@ module Grumlin
     def initialize
       return if respond_to?(:shortcuts)
 
-      raise RuntimerError,
-            "steppable must not be initialized directly, use Grumlin::Shortcuts::Storage#g or #__ instead"
+      raise "steppable must not be initialized directly, use Grumlin::Shortcuts::Storage#g or #__ instead"
     end
 
     ALL_STEPS.each do |step|

--- a/lib/grumlin/traversal_start.rb
+++ b/lib/grumlin/traversal_start.rb
@@ -2,6 +2,8 @@
 
 module Grumlin
   class TraversalStart < Steppable
+    include WithExtension
+
     def to_s(*)
       self.class.to_s
     end

--- a/lib/grumlin/traversal_strategies/options_strategy.rb
+++ b/lib/grumlin/traversal_strategies/options_strategy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Grumlin
+  module TraversalStrategies
+    class OptionsStrategy < TypedValue
+      def initialize(value)
+        super(type: "OptionsStrategy", value: value)
+      end
+    end
+  end
+end

--- a/lib/grumlin/version.rb
+++ b/lib/grumlin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grumlin
-  VERSION = "0.20.1"
+  VERSION = "0.20.2"
 end

--- a/lib/grumlin/with_extension.rb
+++ b/lib/grumlin/with_extension.rb
@@ -3,8 +3,14 @@
 module Grumlin
   module WithExtension
     def with(name, value)
-      with_action_class.new(:withStrategies, args: [TraversalStrategies::OptionsStrategy.new({ name => value })],
-                                             previous_step: self)
+      prev = self
+      strategy = if is_a?(with_action_class)
+                   prev = previous_step
+                   TraversalStrategies::OptionsStrategy.new(args.first.value.merge(name => value))
+                 else
+                   TraversalStrategies::OptionsStrategy.new({ name => value })
+                 end
+      with_action_class.new(:withStrategies, args: [strategy], previous_step: prev)
     end
 
     private

--- a/lib/grumlin/with_extension.rb
+++ b/lib/grumlin/with_extension.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Grumlin
+  module WithExtension
+    def with(name, value)
+      with_action_class.new(:withStrategies, args: [TraversalStrategies::OptionsStrategy.new({ name => value })],
+                                             previous_step: self)
+    end
+
+    private
+
+    def with_action_class
+      @with_action_class ||= Class.new(shortcuts.action_class) do
+        include WithExtension
+
+        def with_action_class
+          self.class
+        end
+      end
+    end
+  end
+end

--- a/spec/grumlin/with_extension_spec.rb
+++ b/spec/grumlin/with_extension_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Grumlin::WithExtension, gremlin: true do
     it "adds withStrategies step with OptionStrategy argument" do
       expect(subject).to eq({ step: [[:V], [:valueMap], [:with, "~tinkerpop.valueMap.tokens"]],
                               source: [[:withStrategies,
-                                        { :@type => "g:OptionsStrategy", :@value => { some_name: "some_value" } }],
-                                       [:withStrategies,
-                                        { :@type => "g:OptionsStrategy", :@value => { other_name: "other_value" } }]] })
+                                        { :@type => "g:OptionsStrategy", :@value => { some_name: "some_value", other_name: "other_value" } }]] })
     end
   end
 end

--- a/spec/grumlin/with_extension_spec.rb
+++ b/spec/grumlin/with_extension_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Grumlin::WithExtension, gremlin: true do
+  let(:shortcuts) { Grumlin::Shortcuts::Storage.new }
+
+  let(:klass) do
+    Class.new(shortcuts.traversal_start_class) do
+      include Grumlin::WithExtension
+    end
+  end
+
+  let(:traversal_start) { klass.new }
+
+  describe "#with" do
+    subject { traversal_start.with(:some_name, "some_value").with(:other_name, "other_value").V.valueMap.with(WithOptions.tokens).bytecode.serialize }
+
+    it "adds withStrategies step with OptionStrategy argument" do
+      expect(subject).to eq({ step: [[:V], [:valueMap], [:with, "~tinkerpop.valueMap.tokens"]],
+                              source: [[:withStrategies,
+                                        { :@type => "g:OptionsStrategy", :@value => { some_name: "some_value" } }],
+                                       [:withStrategies,
+                                        { :@type => "g:OptionsStrategy", :@value => { other_name: "other_value" } }]] })
+    end
+  end
+end


### PR DESCRIPTION
New steps: 
- withStrategies

New features:
- `g.with("name", "value")` added as a shortcuts for g.withStrategies(Grumlin::TraversalStrategies::OptionStrategy({"name" => "value"}))

Note:
it is possible to chain multiple `with`, their values will be merged, and only one one `withStrategies` configuration step will be sent to the server:
`g.with(:a, 1).with(:b, 2).V` will contain `withStrategies(Grumlin::TraversalStrategies::OptionStrategy({a: 1, b: 2}))`