### PR TITLE
Add support for cardinality to the props shortcut

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grumlin (0.20.3)
+    grumlin (0.21.0)
       async-pool (~> 0.3)
       async-websocket (~> 0.19)
       oj (~> 3.13)
@@ -72,7 +72,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
-    oj (3.13.17)
+    oj (3.13.18)
     overcommit (0.59.1)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)

--- a/gremlin_server/Dockerfile
+++ b/gremlin_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tinkerpop/gremlin-server
+FROM tinkerpop/gremlin-server:3.5.3
 
 RUN rm -rf /opt/gremlin-server/ext/tinkergraph-gremlin
 

--- a/lib/grumlin/shortcuts/properties.rb
+++ b/lib/grumlin/shortcuts/properties.rb
@@ -5,11 +5,12 @@ module Grumlin
     module Properties
       extend Grumlin::Shortcuts
 
-      shortcut :props do |**props|
-        props.reduce(self) do |tt, (prop, value)| # rubocop:disable Style/EachWithObject
-          next tt.property(prop, value) unless value.nil? # nils are not supported
+      shortcut :props do |cardinality = nil, **props|
+        props.reduce(self) do |tt, (prop, value)|
+          next tt if value.nil? # nils are not supported
+          next tt.property(prop, value) if cardinality.nil?
 
-          tt
+          tt.property(cardinality, prop, value)
         end
       end
 

--- a/lib/grumlin/shortcuts/upserts.rb
+++ b/lib/grumlin/shortcuts/upserts.rb
@@ -10,8 +10,8 @@ module Grumlin
             .fold
             .coalesce(
               __.unfold,
-              __.addV(label).props(**create_properties.merge(T.id => id))
-            ).props(**update_properties)
+              __.addV(label).props(Cardinality.single, **create_properties.merge(T.id => id))
+            ).props(Cardinality.single, **update_properties)
       end
 
       shortcut :upsertE do |label, from, to, create_properties = {}, update_properties = {}|

--- a/lib/grumlin/version.rb
+++ b/lib/grumlin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grumlin
-  VERSION = "0.20.3"
+  VERSION = "0.21.0"
 end

--- a/spec/grumlin/shortcuts/properties_spec.rb
+++ b/spec/grumlin/shortcuts/properties_spec.rb
@@ -2,12 +2,24 @@
 
 RSpec.describe Grumlin::Shortcuts::Properties do
   describe "shortcut props" do
-    it "converts a hash into a charin of property calls" do
-      object1 = double(property: nil) # rubocop:disable RSpec/VerifiedDoubles
-      object = double(property: object1) # rubocop:disable RSpec/VerifiedDoubles
-      described_class.shortcuts[:props].apply(object, a: 1, b: 2)
-      expect(object).to have_received(:property).with(:a, 1)
-      expect(object1).to have_received(:property).with(:b, 2)
+    context "when cardinality is not passed" do
+      it "converts a hash into a charin of property calls" do
+        object1 = double(property: nil) # rubocop:disable RSpec/VerifiedDoubles
+        object = double(property: object1) # rubocop:disable RSpec/VerifiedDoubles
+        described_class.shortcuts[:props].apply(object, a: 1, b: 2)
+        expect(object).to have_received(:property).with(:a, 1)
+        expect(object1).to have_received(:property).with(:b, 2)
+      end
+    end
+
+    context "when cardinality is passed" do
+      it "converts a hash into a charin of property calls" do
+        object1 = double(property: nil) # rubocop:disable RSpec/VerifiedDoubles
+        object = double(property: object1) # rubocop:disable RSpec/VerifiedDoubles
+        described_class.shortcuts[:props].apply(object, Grumlin::Expressions::Cardinality.single, a: 1, b: 2)
+        expect(object).to have_received(:property).with(Grumlin::Expressions::Cardinality.single, :a, 1)
+        expect(object1).to have_received(:property).with(Grumlin::Expressions::Cardinality.single, :b, 2)
+      end
     end
   end
 

--- a/spec/grumlin/shortcuts/upserts_spec.rb
+++ b/spec/grumlin/shortcuts/upserts_spec.rb
@@ -7,24 +7,23 @@ RSpec.describe Grumlin::Shortcuts::Upserts do
     it "uses coalesce to upsert a vertex" do
       t = Grumlin::Shortcuts::Properties.shortcuts.__
       result = described_class.shortcuts[:upsertV].apply(t, "test", 1, { a: 1 }, { b: 2 })
+
       expect(result.bytecode.serialize).to eq({
-                                                step:
-                                                  [
-                                                    [:V, 1],
-                                                    [:fold],
-                                                    [:coalesce, { :@type => "g:Bytecode", :@value => { step: [[:unfold]] } },
-                                                     {
-                                                       :@type => "g:Bytecode",
-                                                       :@value => {
-                                                         step: [
-                                                           [:addV, "test"],
-                                                           [:property, :a, 1],
-                                                           [:property, { :@type => "g:T", :@value => :id }, 1]
-                                                         ]
-                                                       }
-                                                     }],
-                                                    [:property, :b, 2]
-                                                  ]
+                                                step: [
+                                                  [:V, 1],
+                                                  [:fold],
+                                                  [:coalesce,
+                                                   { :@type => "g:Bytecode", :@value => { step: [[:unfold]] } },
+                                                   { :@type => "g:Bytecode",
+                                                     :@value =>
+                                                      { step: [[:addV, "test"],
+                                                               [:property, { :@type => "g:Cardinality", :@value => :single }, :a, 1],
+                                                               [:property,
+                                                                { :@type => "g:Cardinality", :@value => :single },
+                                                                { :@type => "g:T", :@value => :id },
+                                                                1]] } }],
+                                                  [:property, { :@type => "g:Cardinality", :@value => :single }, :b, 2]
+                                                ]
                                               })
     end
   end


### PR DESCRIPTION
Use `Cardinality.single` for vertex upserts by default

Fixes https://github.com/babbel/grumlin/issues/98