### PR TITLE
Convert g:Direction to symbol

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grumlin (1.0.0.rc3)
+    grumlin (1.0.0.rc4)
       async-pool (~> 0.3)
       async-websocket (>= 0.19, < 0.20)
       ibsciss-middleware (~> 0.4.0)

--- a/lib/grumlin/typing.rb
+++ b/lib/grumlin/typing.rb
@@ -13,7 +13,7 @@ module Grumlin::Typing
     "g:Int64" => ->(value) { cast_int(value) },
     "g:Int32" => ->(value) { cast_int(value) },
     "g:Double" => ->(value) { cast_double(value) },
-    "g:Direction" => ->(value) { value },
+    "g:Direction" => ->(value) { value.to_sym },
     "g:VertexProperty" => ->(value) { cast_entity(Grumlin::VertexProperty, value) },
     "g:TraversalMetrics" => ->(value) { cast_map(value[:@value]) },
     "g:Metrics" => ->(value) { cast_map(value[:@value]) },

--- a/lib/grumlin/version.rb
+++ b/lib/grumlin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grumlin
-  VERSION = "1.0.0.rc3"
+  VERSION = "1.0.0.rc4"
 end

--- a/spec/grumlin/practical_gremlin/2_walking_spec.rb
+++ b/spec/grumlin/practical_gremlin/2_walking_spec.rb
@@ -413,8 +413,8 @@ RSpec.describe "Practical Gramlin: walking" do
                                                                      { desc: "Austin Bergstrom International Airport" }])
 
     expect(g.V().has("code", "AUS").elementMap("city").toList).to eq([{ city: "Austin", T.id => 3, T.label => "airport" }])
-    expect(g.V(3).outE.limit(1).elementMap.toList).to eq([{ "IN" => { T.id => 47, T.label =>  "airport" },
-                                                            "OUT" => { T.id => 3, T.label =>  "airport" },
+    expect(g.V(3).outE.limit(1).elementMap.toList).to eq([{ :IN => { T.id => 47, T.label =>  "airport" },
+                                                            :OUT => { T.id => 3, T.label =>  "airport" },
                                                             :dist => 1357,
                                                             T.id => 5161,
                                                             T.label => "route" }])

--- a/spec/grumlin/repository/instance_methods_spec.rb
+++ b/spec/grumlin/repository/instance_methods_spec.rb
@@ -242,8 +242,8 @@ RSpec.describe Grumlin::Repository::InstanceMethods, gremlin_server: true do
       it "creates an edge" do
         expect { subject }.to change { g.E.count.next }.by(1)
         expect(g.E(id).elementMap.next).to eq({ T.id => 123, T.label => "test_label",
-                                                "IN" => { T.id => 2, T.label => "test" },
-                                                "OUT" => { T.id => 1, T.label => "test" },
+                                                :IN => { T.id => 2, T.label => "test" },
+                                                :OUT => { T.id => 1, T.label => "test" },
                                                 key: "value" })
       end
 
@@ -253,8 +253,8 @@ RSpec.describe Grumlin::Repository::InstanceMethods, gremlin_server: true do
         it "creates an edge" do
           expect { subject }.to change { g.E.count.next }.by(1)
           expect(g.E(id).elementMap.next).to eq({ T.id => 123, T.label => "test_label",
-                                                  "IN" => { T.id => 2, T.label => "test" },
-                                                  "OUT" => { T.id => 1, T.label => "test" },
+                                                  :IN => { T.id => 2, T.label => "test" },
+                                                  :OUT => { T.id => 1, T.label => "test" },
                                                   key: "value" })
         end
       end
@@ -267,8 +267,8 @@ RSpec.describe Grumlin::Repository::InstanceMethods, gremlin_server: true do
       it "creates an edge" do
         expect { subject }.to change { g.E.count.next }.by(1)
         expect(g.E(124).elementMap.next).to eq({ T.id => 124, T.label => "test_label",
-                                                 "IN" => { T.id => 2, T.label => "test" },
-                                                 "OUT" => { T.id => 1, T.label => "test" },
+                                                 :IN => { T.id => 2, T.label => "test" },
+                                                 :OUT => { T.id => 1, T.label => "test" },
                                                  key: "value" })
       end
     end
@@ -354,8 +354,8 @@ RSpec.describe Grumlin::Repository::InstanceMethods, gremlin_server: true do
       it "creates an edge" do
         expect { subject }.to change { g.E.count.next }.by(1)
         expect(g.E(1234).elementMap.next).to eq({ T.id => 1234, T.label => "test",
-                                                  "IN" => { T.id => 2, T.label => "test" },
-                                                  "OUT" => { T.id => 1, T.label => "test" },
+                                                  :IN => { T.id => 2, T.label => "test" },
+                                                  :OUT => { T.id => 1, T.label => "test" },
                                                   another_key: "another_value", key: "value" })
       end
     end
@@ -372,8 +372,8 @@ RSpec.describe Grumlin::Repository::InstanceMethods, gremlin_server: true do
       it "updates properties with update_properties" do
         subject
         expect(g.E(1234).elementMap.next).to eq({ T.id => 1234, T.label => "test",
-                                                  "IN" => { T.id => 2, T.label => "test" },
-                                                  "OUT" => { T.id => 1, T.label => "test" },
+                                                  :IN => { T.id => 2, T.label => "test" },
+                                                  :OUT => { T.id => 1, T.label => "test" },
                                                   another_key: "another_value" })
       end
     end

--- a/spec/grumlin/repository_spec.rb
+++ b/spec/grumlin/repository_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
 
       it "assigns default properties" do
         repository.g.addE(:test).property(T.id, :test_edge).from(__.V(1)).to(__.V(2)).iterate
-        expect(repository.g.E(:test_edge).elementMap.next).to eq({ T.id => "test_edge", T.label => "test", "IN" => { T.id => 2, T.label => "test" }, "OUT" => { T.id => 1, T.label => "test" }, edge: true, default_label: "test" })
+        expect(repository.g.E(:test_edge).elementMap.next).to eq({ T.id => "test_edge", T.label => "test", :IN => { T.id => 2, T.label => "test" }, :OUT => { T.id => 1, T.label => "test" }, edge: true, default_label: "test" })
       end
     end
 
@@ -447,7 +447,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
 
       it "assigns default properties" do
         repository.add_edge(:test, T.id => :test_edge, from: 1, to: 2)
-        expect(repository.g.E(:test_edge).elementMap.next).to eq({ T.id => "test_edge", T.label => "test", "IN" => { T.id => 2, T.label => "test" }, "OUT" => { T.id => 1, T.label => "test" }, edge: true, default_label: "test" })
+        expect(repository.g.E(:test_edge).elementMap.next).to eq({ T.id => "test_edge", T.label => "test", :IN => { T.id => 2, T.label => "test" }, :OUT => { T.id => 1, T.label => "test" }, edge: true, default_label: "test" })
       end
     end
 
@@ -466,7 +466,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
 
       it "assigns default properties" do
         repository.g.upsertE(:test, 1, 2).iterate
-        expect(repository.g.E.hasLabel(:test).elementMap.next.except(T.id)).to eq({ T.label => "test", "IN" => { T.id => 2, T.label => "test" }, "OUT" => { T.id => 1, T.label => "test" }, edge: true, default_label: "test" })
+        expect(repository.g.E.hasLabel(:test).elementMap.next.except(T.id)).to eq({ T.label => "test", :IN => { T.id => 2, T.label => "test" }, :OUT => { T.id => 1, T.label => "test" }, edge: true, default_label: "test" })
       end
     end
 
@@ -502,7 +502,7 @@ RSpec.describe Grumlin::Repository, gremlin_server: true do
 
         it "assigns default properties" do
           repository.g.addE(:test).property(T.id, :test_edge).from(__.V(1)).to(__.V(2)).iterate
-          expect(repository.g.E(:test_edge).elementMap.next).to eq({ T.id => "test_edge", T.label => "test", "IN" => { T.id => 2, T.label => "test" }, "OUT" => { T.id => 1, T.label => "test" }, edge: true, default_label: "test", inherited: true })
+          expect(repository.g.E(:test_edge).elementMap.next).to eq({ T.id => "test_edge", T.label => "test", :IN => { T.id => 2, T.label => "test" }, :OUT => { T.id => 1, T.label => "test" }, edge: true, default_label: "test", inherited: true })
         end
       end
     end


### PR DESCRIPTION
Breaking change!

Query:
```ruby
g.E.limit(1).elementMap.next
```

Before:

```ruby
{T.id=>"83e964bb-3692-44e6-eaf4-39c65f8b2c59",
 T.label=>"label",
 "IN"=>{T.id=>"blah", T.label=>"label"},
 "OUT"=>{T.id=>"blah", T.label=>"label"}
}
```

After:

```ruby
{T.id=>"83e964bb-3692-44e6-eaf4-39c65f8b2c59",
 T.label=>"label",
 :IN=>{T.id=>"blah", T.label=>"label"},
 :OUT=>{T.id=>"blah", T.label=>"label"},
}
```